### PR TITLE
Add (Modded) text to challenge moon leaderboard

### DIFF
--- a/LobbyCompatibility/Patches/GetLeaderboardForChallengeTranspiler.cs
+++ b/LobbyCompatibility/Patches/GetLeaderboardForChallengeTranspiler.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using HarmonyLib;
+using LobbyCompatibility.Enums;
+using Steamworks.Data;
+
+namespace LobbyCompatibility.Patches;
+
+/// <summary>
+///     Patches <see cref="MenuManager.GetLeaderboardForChallenge" />.
+///     Overrides the challenge moon leaderboard title text by appending (Modded) to the end
+/// </summary>
+/// <seealso cref="MenuManager.GetLeaderboardForChallenge" />
+// ReSharper disable UnusedMember.Local
+[HarmonyPatch]
+[HarmonyPriority(Priority.Last)]
+[HarmonyWrapSafe]
+internal static class GetLeaderboardForChallengeTranspiler
+{
+    [HarmonyTargetMethod]
+    private static MethodBase TargetMethod()
+    {
+        return AccessTools.Method(typeof(MenuManager), nameof(MenuManager.GetLeaderboardForChallenge))
+            .GetCustomAttribute<AsyncStateMachineAttribute>()
+            .StateMachineType.GetMethod("MoveNext", BindingFlags.Instance | BindingFlags.NonPublic);
+    }
+
+    [HarmonyTranspiler]
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions)
+            .SearchForward(instruction => instruction.OperandIs(" Results"))
+            .ThrowIfInvalid("Could not find leaderboard results text")
+            .SetOperandAndAdvance(" Results (Modded)")
+            .InstructionEnumeration();
+    }
+}

--- a/LobbyCompatibility/Patches/GetLeaderboardForChallengeTranspiler.cs
+++ b/LobbyCompatibility/Patches/GetLeaderboardForChallengeTranspiler.cs
@@ -1,10 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
-using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using HarmonyLib;
-using LobbyCompatibility.Enums;
-using Steamworks.Data;
 
 namespace LobbyCompatibility.Patches;
 

--- a/LobbyCompatibility/Patches/MenuManagerPostfix.cs
+++ b/LobbyCompatibility/Patches/MenuManagerPostfix.cs
@@ -27,6 +27,9 @@ internal static class MenuManagerPostfix
 
         LobbyCompatibilityPlugin.Logger?.LogInfo("Initializing menu UI.");
 
+        // Set challenge moon leaderboard title text to not wrap halfway through
+        __instance.leaderboardHeaderText.rectTransform.offsetMax = new Vector2(2000, __instance.leaderboardHeaderText.rectTransform.offsetMax.y);
+
         // Setup hover notification/tooltip UI
         var modListTooltipPanel =
             Object.Instantiate(__instance.menuNotification, __instance.menuNotification.transform.parent);


### PR DESCRIPTION
Adds feature from #19 

![Lethal_Company_OoMe0z2te7](https://github.com/MaxWasUnavailable/LobbyCompatibility/assets/34404266/d84bfd35-c378-460b-9063-c6378a158e39)
