### PR TITLE
Refactor LoadLobyListAndFilter Transpiler

### DIFF
--- a/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
+++ b/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
@@ -25,10 +25,7 @@ public class ModdedLobbySlot : MonoBehaviour
     // Runs after LobbySlot data set
     internal void Setup(LobbySlot lobbySlot)
     {
-        // Not 100% ideal, but I don't want to mess with IL/stack weirdness too much right now
         _lobbySlot = lobbySlot;
-        if (_lobbySlot == null)
-            return;
 
         // Get the "diff" of the lobby
         _lobbyDiff = LobbyHelper.GetLobbyDiff(_lobbySlot.thisLobby);

--- a/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
+++ b/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
@@ -23,11 +23,10 @@ public class ModdedLobbySlot : MonoBehaviour
     private Transform? _parentContainer;
 
     // Runs after LobbySlot data set
-    // TODO: Review & refactor
-    private void Start()
+    internal void Setup(LobbySlot lobbySlot)
     {
         // Not 100% ideal, but I don't want to mess with IL/stack weirdness too much right now
-        _lobbySlot = GetComponent<LobbySlot>();
+        _lobbySlot = lobbySlot;
         if (_lobbySlot == null)
             return;
 


### PR DESCRIPTION
Improves compatibility, performance, and reliability of the ModdedLobbySlots.

Resolves #18.

Basic summary of new transpiler:
```cs
// - Adds dup before last componentInChildren line to keep componentInChildren value on the stack
// - Loads SteamLobbyManager.levelListContainer onto the stack
// - Calls InitializeLobbySlot(lobbySlot, levelListContainer)
```