### PR TITLE
Feat lobbydiff unknown

### DIFF
--- a/LobbyCompatibility/Enums/LobbyDiffResult.cs
+++ b/LobbyCompatibility/Enums/LobbyDiffResult.cs
@@ -17,7 +17,12 @@ public enum LobbyDiffResult
     Incompatible,
 
     /// <summary>
-    ///     Mod list does not exist, and lobby might be compatible.
+    ///     Mod list is compatible, except for unknown mods.
+    /// </summary>
+    PresumedCompatible,
+
+    /// <summary>
+    ///     Mod list information is not available, server does not have LobbyCompatibility installed, or other unknown cause.
     ///     Also applies to vanilla lobbies.
     /// </summary>
     Unknown

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -16,7 +16,7 @@ internal static class LobbyHelper
     public static Dictionary<string, string> LatestLobbyRequestStringFilters = new();
     public static LobbyDistanceFilter? LatestLobbyRequestDistanceFilter;
 
-    private static Dictionary<ulong, LobbyDiff> _lobbyDiffCache { get; set; } = new();
+    private static Dictionary<ulong, LobbyDiff> LobbyDiffCache { get; set; } = new();
     private static List<PluginInfoRecord>? _clientPlugins;
 
     /// <summary>
@@ -26,7 +26,7 @@ internal static class LobbyHelper
     /// <returns> The <see cref="LobbyDiff" /> from the <see cref="Lobby" />. </returns>
     public static LobbyDiff GetLobbyDiff(Lobby lobby)
     {
-        if (_lobbyDiffCache.TryGetValue(lobby.Id, out LobbyDiff cachedLobbyDiff))
+        if (LobbyDiffCache.TryGetValue(lobby.Id, out LobbyDiff cachedLobbyDiff))
             return cachedLobbyDiff;
 
         var lobbyPlugins = PluginHelper
@@ -100,7 +100,7 @@ internal static class LobbyHelper
         LatestLobbyDiff = new LobbyDiff(pluginDiffs);
 
         // Add to cache to avoid making multiple unnecessary GetData() calls
-        _lobbyDiffCache.Add(lobby.Id, LatestLobbyDiff);
+        LobbyDiffCache.Add(lobby.Id, LatestLobbyDiff);
 
         return LatestLobbyDiff;
     }

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -96,8 +96,10 @@ internal static class LobbyHelper
                 pluginDiffs.Add(new PluginDiff(PluginDiffResult.Compatible, clientPlugin.GUID,
                     clientPlugin.Version, null));
         }
+        
+        var lobbyCompatibilityPresent = lobbyPlugins.Any();
 
-        LatestLobbyDiff = new LobbyDiff(pluginDiffs);
+        LatestLobbyDiff = new LobbyDiff(pluginDiffs, lobbyCompatibilityPresent);
 
         // Add to cache to avoid making multiple unnecessary GetData() calls
         LobbyDiffCache.Add(lobby.Id, LatestLobbyDiff);

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -186,12 +186,15 @@ internal static class PluginHelper
     }
 
     /// <summary>
-    ///     Checks if client is allowed to join vanilla lobbies.
+    ///     Checks if client is allowed to join vanilla or unknown lobbies.
     /// </summary>
-    /// <returns> True if client is allowed to join vanilla lobbies, false otherwise. </returns>
+    /// <returns> True if client is allowed to join vanilla or unknown lobbies, false otherwise. </returns>
+    /// <remarks> This means the client is allowed to have unknown or clientside mods. </remarks>
     internal static bool CanJoinVanillaLobbies()
     {
-        return GetAllPluginInfo().All(plugin => plugin.CompatibilityLevel is CompatibilityLevel.ClientOnly or null);
+        return GetAllPluginInfo().All(plugin =>
+            plugin.CompatibilityLevel != CompatibilityLevel.ServerOnly &&
+            plugin.CompatibilityLevel != CompatibilityLevel.ClientOptional);
     }
 
     /// <summary>

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -193,7 +193,7 @@ internal static class PluginHelper
     internal static bool CanJoinVanillaLobbies()
     {
         return GetAllPluginInfo().All(plugin =>
-            plugin.CompatibilityLevel != CompatibilityLevel.ServerOnly &&
+            plugin.CompatibilityLevel != CompatibilityLevel.Everyone &&
             plugin.CompatibilityLevel != CompatibilityLevel.ClientOptional);
     }
 


### PR DESCRIPTION
Generally supports unknown lobbies & mods better by assuming they're compatible. Is explicit through a new LobbyDiffResult.PresumedCompatible enum value.