### PR TITLE
Add Pagination to Lobby Metadata

### DIFF
--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using HarmonyLib;
 using LobbyCompatibility.Enums;
 using LobbyCompatibility.Models;
 using Steamworks;
@@ -24,13 +25,21 @@ internal static class LobbyHelper
     /// </summary>
     /// <param name="lobby"> The lobby to get the diff from. </param>
     /// <returns> The <see cref="LobbyDiff" /> from the <see cref="Lobby" />. </returns>
-    public static LobbyDiff GetLobbyDiff(Lobby lobby)
-    {
-        if (_lobbyDiffCache.TryGetValue(lobby.Id, out LobbyDiff cachedLobbyDiff))
-            return cachedLobbyDiff;
+    public static LobbyDiff GetLobbyDiff(Lobby lobby) => GetLobbyDiff(lobby, null);
 
+    /// <summary>
+    ///     Get a <see cref="LobbyDiff" /> from a <see cref="Lobby" /> or <see cref="IEnumerable{String}" />.
+    /// </summary>
+    /// <param name="lobby"> The lobby to cache the diff to and/or get the diff from. </param>
+    /// <param name="lobbyPluginString"> The json string to parse. </param>
+    /// <returns> The <see cref="LobbyDiff" />. </returns>
+    internal static LobbyDiff GetLobbyDiff(Lobby lobby, string? lobbyPluginString)
+    {
+        if (_lobbyDiffCache.TryGetValue(lobby.Id, out var cachedLobbyDiff))
+            return cachedLobbyDiff;
+        
         var lobbyPlugins = PluginHelper
-            .ParseLobbyPluginsMetadata(lobby.GetData(LobbyMetadata.Plugins)).ToList();
+            .ParseLobbyPluginsMetadata(lobbyPluginString ?? GetLobbyPlugins(lobby)).ToList();
         _clientPlugins ??= PluginHelper.GetAllPluginInfo().ToList();
 
         var pluginDiffs = new List<PluginDiff>();
@@ -103,6 +112,24 @@ internal static class LobbyHelper
         _lobbyDiffCache.Add(lobby.Id, LatestLobbyDiff);
 
         return LatestLobbyDiff;
+    }
+    
+    /// <summary>
+    ///     Get the plugins json from a <see cref="Lobby" />.
+    /// </summary>
+    /// <param name="lobby"> The <see cref="Lobby" /> to get the json string from. </param>
+    /// <returns> A json <see cref="string" /> from the <see cref="Lobby" />. </returns>
+    internal static string GetLobbyPlugins(Lobby lobby)
+    {
+        string[] lobbyPluginStrings = [];
+        var i = 0;
+
+        do lobbyPluginStrings[i] = lobby.GetData($"{LobbyMetadata.Plugins}{i}");
+        while (lobbyPluginStrings[i++].Contains("@"));
+
+        return lobbyPluginStrings
+            .Join(delimiter: string.Empty)
+            .Replace("@", string.Empty);
     }
 
     public static string GetCompatibilityHeader(PluginDiffResult pluginDiffResult)

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -121,10 +121,10 @@ internal static class LobbyHelper
     /// <returns> A json <see cref="string" /> from the <see cref="Lobby" />. </returns>
     internal static string GetLobbyPlugins(Lobby lobby)
     {
-        string[] lobbyPluginStrings = [];
+        var lobbyPluginStrings = new List<string>();
         var i = 0;
 
-        do lobbyPluginStrings[i] = lobby.GetData($"{LobbyMetadata.Plugins}{i}");
+        do lobbyPluginStrings.Insert(i, lobby.GetData($"{LobbyMetadata.Plugins}{i}"));
         while (lobbyPluginStrings[i++].Contains("@"));
 
         return lobbyPluginStrings

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -109,20 +109,15 @@ internal static class PluginHelper
     internal static IEnumerable<string> GetLobbyPluginsMetadata()
     {
         var json = JsonConvert.SerializeObject(GetAllPluginInfo().ToList(), new VersionConverter());
-        
-        LobbyCompatibilityPlugin.Logger?.LogDebug(json);
 
-        // The maximum string size for steam lobby metadata is 8196 (2^13).
+        // The maximum string size for steam lobby metadata is 8192 (2^13).
         // We want one less than the maximum to allow space for a delimiter
-        var maxChunkLength = 8195;
+        var maxChunkLength = 8191;
         
         for (var i = 0; i < json.Length; i += maxChunkLength)
         {
             if (maxChunkLength + i > json.Length)
                 maxChunkLength = json.Length - i;
-            
-            
-            LobbyCompatibilityPlugin.Logger?.LogDebug(json.Substring(i, maxChunkLength));
 
             yield return json.Substring(i, maxChunkLength);
         }

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -103,12 +103,29 @@ internal static class PluginHelper
     }
 
     /// <summary>
-    ///     Creates a json string containing the metadata of all plugins, to add to the lobby.
+    ///     Creates a list of json strings containing the metadata of all plugins, to add to the lobby.
     /// </summary>
-    /// <returns> A json string containing the metadata of all plugins. </returns>
-    internal static string GetLobbyPluginsMetadata()
+    /// <returns> A list of json strings containing the metadata of all plugins. </returns>
+    internal static IEnumerable<string> GetLobbyPluginsMetadata()
     {
-        return JsonConvert.SerializeObject(GetAllPluginInfo().ToList(), new VersionConverter());
+        var json = JsonConvert.SerializeObject(GetAllPluginInfo().ToList(), new VersionConverter());
+        
+        LobbyCompatibilityPlugin.Logger?.LogDebug(json);
+
+        // The maximum string size for steam lobby metadata is 8196 (2^13).
+        // We want one less than the maximum to allow space for a delimiter
+        var maxChunkLength = 8195;
+        
+        for (var i = 0; i < json.Length; i += maxChunkLength)
+        {
+            if (maxChunkLength + i > json.Length)
+                maxChunkLength = json.Length - i;
+            
+            
+            LobbyCompatibilityPlugin.Logger?.LogDebug(json.Substring(i, maxChunkLength));
+
+            yield return json.Substring(i, maxChunkLength);
+        }
     }
 
     /// <summary>

--- a/LobbyCompatibility/Models/PluginInfoRecord.cs
+++ b/LobbyCompatibility/Models/PluginInfoRecord.cs
@@ -16,16 +16,16 @@ namespace LobbyCompatibility.Models;
 /// <param name="VersionStrictness"> The version strictness of the plugin. </param>
 [Serializable]
 public record PluginInfoRecord(
-    [property:JsonProperty("id")]
+    [property:JsonProperty("i")]
     string GUID,
     
     [property:JsonProperty("v")]
     [property: JsonConverter(typeof(VersionConverter))]
     Version Version,
     
-    [property:JsonProperty("cl")]
+    [property:JsonProperty("c")]
     CompatibilityLevel? CompatibilityLevel,
     
-    [property:JsonProperty("vs")]
+    [property:JsonProperty("s")]
     VersionStrictness? VersionStrictness
 );

--- a/LobbyCompatibility/Models/PluginInfoRecord.cs
+++ b/LobbyCompatibility/Models/PluginInfoRecord.cs
@@ -16,9 +16,16 @@ namespace LobbyCompatibility.Models;
 /// <param name="VersionStrictness"> The version strictness of the plugin. </param>
 [Serializable]
 public record PluginInfoRecord(
+    [property:JsonProperty("id")]
     string GUID,
+    
+    [property:JsonProperty("v")]
     [property: JsonConverter(typeof(VersionConverter))]
     Version Version,
+    
+    [property:JsonProperty("cl")]
     CompatibilityLevel? CompatibilityLevel,
+    
+    [property:JsonProperty("vs")]
     VersionStrictness? VersionStrictness
 );

--- a/LobbyCompatibility/Patches/LobbyDataIsJoinablePostfix.cs
+++ b/LobbyCompatibility/Patches/LobbyDataIsJoinablePostfix.cs
@@ -34,10 +34,10 @@ internal static class LobbyDataIsJoinablePostfix
             return PluginHelper.CanJoinVanillaLobbies() && isJoinable;
         }
 
-        var lobbyPluginString = lobby.GetData(LobbyMetadata.Plugins);
+        var lobbyPluginString = LobbyHelper.GetLobbyPlugins(lobby).Join(delimiter: string.Empty);
 
         // Create lobby diff so LatestLobbyDiff is set
-        LobbyHelper.GetLobbyDiff(lobby);
+        LobbyHelper.GetLobbyDiff(lobby, lobbyPluginString);
 
         // If the lobby does not have any plugin information, return original result (since we can't check anything)
         if (string.IsNullOrEmpty(lobbyPluginString))

--- a/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
+++ b/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
@@ -29,8 +29,11 @@ internal static class SteamMatchmakingOnLobbyCreatedPostfix
         // Modded is flagged as true, since we're using mods
         lobby.SetData(LobbyMetadata.Modded, "true");
 
-        // Add plugin metadata to the lobby so clients can check if they have the required plugins
-        lobby.SetData(LobbyMetadata.Plugins, PluginHelper.GetLobbyPluginsMetadata());
+        // Add paginated plugin metadata to the lobby so clients can check if they have the required plugins
+        var plugins = PluginHelper.GetLobbyPluginsMetadata().ToArray();
+        // Add each page - with a delimiter if there's another page
+        for (var i = 0; i < plugins.Length; i++)
+            lobby.SetData($"{LobbyMetadata.Plugins}{i}", $"{plugins[i]}{(i < plugins.Length - 1 ? "@" : string.Empty)}");
 
         // Set the joinable modded metadata to the same value as the original joinable metadata, in case it wasn't originally joinable
         lobby.SetData(LobbyMetadata.JoinableModded, lobby.GetData(LobbyMetadata.Joinable));


### PR DESCRIPTION
Resolves #33.

This both shortens the JSON property names and adds pagination to the plugin JSON string in the lobby metadata. The pagination will occur to prevent overloading the metadata value max length of 8192.