### PR TITLE
Fix incompatible LobbyList icon color being white

### DIFF
--- a/LobbyCompatibility/Behaviours/ButtonEventHandler.cs
+++ b/LobbyCompatibility/Behaviours/ButtonEventHandler.cs
@@ -65,6 +65,18 @@ public class ButtonEventHandler : MonoBehaviour, IPointerEnterHandler, IPointerE
         _image = image;
         _normalSprite = normalSprite;
         _highlightedSprite = highlightedSprite;
+
+        SetColor(normalColor, highlightedColor);
+        SetHighlighted(false);
+    }
+
+    /// <summary>
+    ///     Sets the button's color data
+    /// </summary>
+    /// <param name="normalColor"> Color to use when the button is not highlighted </param>
+    /// <param name="highlightedColor"> Color to use when the button is highlighted </param>
+    public void SetColor(Color normalColor, Color highlightedColor)
+    {
         _normalColor = normalColor;
         _highlightedColor = highlightedColor;
 


### PR DESCRIPTION
![Lethal_Company_G4r8eYfMz7](https://github.com/MaxWasUnavailable/LobbyCompatibility/assets/34404266/0e704a4b-cae3-4211-88e8-670415f86911)

A bug in #43 slipped through that made the bright orange "Incompatble" color white
This is because the join button's color isn't loaded until `Awake`, and the ModdedLobbySlot now runs before that

This moves any color-modifying code back to Start() so we can continue copying the join button's color