### PR TITLE
Final checklist pre-demo

### DIFF
--- a/LobbyCompatibility/Behaviours/ModListPanel.cs
+++ b/LobbyCompatibility/Behaviours/ModListPanel.cs
@@ -319,7 +319,11 @@ public class ModListPanel : MonoBehaviour
         _lobbyDiff = lobbyDiff;
 
         // Add some text if necessary on failed join
-        if (titleOverride != null && lobbyDiff.PluginDiffs.Any(x => x.PluginDiffResult == PluginDiffResult.Unknown))
+        if (titleOverride != null && lobbyDiff.GetModdedLobbyType() == LobbyDiffResult.Unknown)
+        {
+            _descriptionText.text = "No lobby mod data available. This lobby is either unmodded, or doesn't have LobbyCompatibility.";
+        }
+        else if (titleOverride != null && lobbyDiff.PluginDiffs.Any(x => x.PluginDiffResult == PluginDiffResult.Unknown))
         {
             _descriptionText.text = "Having trouble joining? Try syncing up your Unknown mods, as they could be causing incompatibilites.";
         }

--- a/LobbyCompatibility/Behaviours/ModListPanel.cs
+++ b/LobbyCompatibility/Behaviours/ModListPanel.cs
@@ -31,6 +31,7 @@ public class ModListPanel : MonoBehaviour
     // Needed for scrolling / content size recalculation
     private ScrollRect? _scrollRect;
     private TextMeshProUGUI? _titleText;
+    private TextMeshProUGUI? _descriptionText;
 
     // Tab data
     private List<ModListTab> _tabs = new();
@@ -50,11 +51,12 @@ public class ModListPanel : MonoBehaviour
     }
 
     /// <summary>
-    ///     Set up our mod list panel using notification & lobby list objects as donors.
+    ///     Set up our mod list panel using notification, lobby list, and host panel objects as donors.
     /// </summary>
     /// <param name="panel"> A notification panel to use as a donor. </param>
     /// <param name="scrollViewTemplate"> A lobby list's scroll view to use as a donor. </param>
-    public void SetupPanel(GameObject panel, Transform scrollViewTemplate)
+    /// <param name="privatePublicDescription"> The host panel's private/public description to use as a donor. </param>
+    public void SetupPanel(GameObject panel, Transform scrollViewTemplate, TextMeshProUGUI privatePublicDescription)
     {
         var panelImage = panel.transform.Find("Panel")?.GetComponent<Image>();
         _panelTransform = panelImage?.rectTransform;
@@ -74,6 +76,12 @@ public class ModListPanel : MonoBehaviour
 
         // Move header up
         _titleText.rectTransform.anchoredPosition = new Vector2(-2f, 155f);
+
+        // Make non-title text
+        _descriptionText = Instantiate(privatePublicDescription, _titleText.transform.parent);
+        _descriptionText.rectTransform.anchoredPosition = new Vector2(-3f, -60f);
+        _descriptionText.rectTransform.sizeDelta = new Vector2(400f, _descriptionText.rectTransform.sizeDelta.y);
+        _descriptionText.text = "";
 
         // Initialize scroll view by taking the game's lobby list and modifying it
         _scrollRect = SetupScrollRect(_panelTransform, scrollViewTemplate, _titleText.color);
@@ -300,7 +308,7 @@ public class ModListPanel : MonoBehaviour
     /// <param name="titleOverride"> Override the title text of the mod list panel. </param>
     public void DisplayNotification(LobbyDiff lobbyDiff, string? titleOverride = null)
     {
-        if (_scrollRect == null || _titleText == null)
+        if (_scrollRect == null || _titleText == null || _descriptionText == null)
             return;
 
         // Set scroll to zero
@@ -309,6 +317,16 @@ public class ModListPanel : MonoBehaviour
         
         // Cache lobby diff to allow tab switching after load
         _lobbyDiff = lobbyDiff;
+
+        // Add some text if necessary on failed join
+        if (titleOverride != null && lobbyDiff.PluginDiffs.Any(x => x.PluginDiffResult == PluginDiffResult.Unknown))
+        {
+            _descriptionText.text = "Having trouble joining? Try syncing up your Unknown mods, as they could be causing incompatibilites.";
+        }
+        else
+        {
+            _descriptionText.text = "";
+        }
 
         // Set the default tab using the config's value, with ModListFilter.All as the default
         SetTab(LobbyCompatibilityPlugin.Config?.DefaultModListTab.Value ?? ModListFilter.All);

--- a/LobbyCompatibility/Behaviours/ModListPanel.cs
+++ b/LobbyCompatibility/Behaviours/ModListPanel.cs
@@ -203,6 +203,9 @@ public class ModListPanel : MonoBehaviour
         // Reset scroll to default position
         scrollRect.verticalNormalizedPosition = 1f;
 
+        // Make scrollrect width consistent
+        scrollRect.verticalScrollbarVisibility = ScrollRect.ScrollbarVisibility.AutoHide;
+
         // Setup ContentSizeFilter and VerticalLayoutGroup so diff elements are automagically spaced
         UIHelper.AddVerticalLayoutGroup(scrollRect.content.gameObject);
 

--- a/LobbyCompatibility/Behaviours/ModListTooltipPanel.cs
+++ b/LobbyCompatibility/Behaviours/ModListTooltipPanel.cs
@@ -211,7 +211,7 @@ public class ModListTooltipPanel : MonoBehaviour
             incompatibleMods = $"<color=red>{incompatibleMods}</color>";
 
         _titleText.text =
-            $"{lobbyDiff.GetDisplayText()}\nTotal Mods: ({lobbyDiff.PluginDiffs.Count})\nIncompatible Mods: {incompatibleMods}\n========================";
+            $"{lobbyDiff.GetDisplayText(true)}\nTotal Mods: ({lobbyDiff.PluginDiffs.Count})\nIncompatible Mods: {incompatibleMods}\n========================";
 
         // Spawn new diffslots
         (_spawnedPluginDiffSlots, _spawnedPluginCategorySlots) = UIHelper.GenerateDiffSlotsFromLobbyDiff(

--- a/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
+++ b/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
@@ -61,17 +61,22 @@ public class ModdedLobbySlot : MonoBehaviour
     private void Start()
     {
         var buttonText = _joinButton?.GetComponentInChildren<TextMeshProUGUI>();
-        if (_lobbyDiff == null || _joinButton == null || buttonText == null)
+        var lobbyDiffResult = _lobbyDiff?.GetModdedLobbyType();
+        if (lobbyDiffResult == null || _joinButton == null || buttonText == null)
             return;
 
-        if (_lobbyDiff.GetModdedLobbyType() != LobbyDiffResult.Incompatible)
+        // Brighter button color should only be applied to incompatible or unknown lobbies
+        if (lobbyDiffResult != LobbyDiffResult.Incompatible && lobbyDiffResult != LobbyDiffResult.Unknown)
             return;
-
-        // If lobby is incompatible, disable the join button (because it won't work)
-        _joinButton.interactable = false;
 
         // If needed, setup brighter button color based on the now-enabled button text
         _buttonEventHandlers.ForEach(handler => handler.SetColor(buttonText.color, buttonText.color));
+
+        // If lobby is incompatible, disable the join button (because it won't work)
+        if (lobbyDiffResult != LobbyDiffResult.Incompatible)
+            return;
+
+        _joinButton.interactable = false;
 
         // Turn joinButton into a modlist button, so we can get the modlist on hover
         SetupModListButtonEvents(_joinButton);

--- a/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
+++ b/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
@@ -224,7 +224,7 @@ public class ModdedLobbySlot : MonoBehaviour
         if (inverted)
             path += "Inverted";
 
-        if (lobbyDiffResult == LobbyDiffResult.Compatible)
+        if (lobbyDiffResult == LobbyDiffResult.Compatible || lobbyDiffResult == LobbyDiffResult.PresumedCompatible)
             path += "ModSettings";
         else if (lobbyDiffResult == LobbyDiffResult.Incompatible)
             path += "ModSettingsExclamationPoint";

--- a/LobbyCompatibility/Behaviours/PluginDiffSlot.cs
+++ b/LobbyCompatibility/Behaviours/PluginDiffSlot.cs
@@ -39,7 +39,8 @@ internal class PluginDiffSlot : MonoBehaviour
     ///     Set the slot's text based on a <see cref="PluginDiff"/>.
     /// </summary>
     /// <param name="pluginDiff"> PluginDiff to display. </param>
-    public void SetPluginDiff(PluginDiff pluginDiff)
+    /// <param name="lobbyCompatibilityPresent"> LobbyCompatibility is installed on the lobby. </param>
+    public void SetPluginDiff(PluginDiff pluginDiff, bool lobbyCompatibilityPresent)
     {
         if (PluginNameText == null)
             return;
@@ -50,7 +51,7 @@ internal class PluginDiffSlot : MonoBehaviour
         // TODO: Something less scary than "X" for compatible mods, but something that still gets the point across
         // TODO: Once we make the unknown lobby changes, all mods should show a "?" for unknown lobbies, because we don't know if they have it or not
         string missingText;
-        if (pluginDiff.PluginDiffResult == PluginDiffResult.Unknown)
+        if (!lobbyCompatibilityPresent && pluginDiff.RequiredVersion == null)
             missingText = "?";
         else
             missingText = "X";

--- a/LobbyCompatibility/Enums/LobbyMetadata.cs
+++ b/LobbyCompatibility/Enums/LobbyMetadata.cs
@@ -51,4 +51,9 @@ public static class LobbyMetadata
     ///     The required plugins checksum to filter against.
     /// </summary>
     public const string RequiredChecksum = "checksum";
+
+    /// <summary>
+    ///     The prefix added before modded lobbies.
+    /// </summary>
+    public const string ModdedLobbyPrefix = "[MOD]";
 }

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -141,7 +141,7 @@ internal static class LobbyHelper
             PluginDiffResult.ClientMissingMod => "Missing lobby-required mods",
             PluginDiffResult.ServerMissingMod => "Incompatible with lobby",
             PluginDiffResult.ModVersionMismatch => "Incompatible mod versions",
-            _ => "Unspecified"
+            _ => "Unknown"
         };
     }
 

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -53,8 +53,10 @@ internal static class LobbyHelper
             if (lobbyPlugin.CompatibilityLevel == null || lobbyPlugin.VersionStrictness == null)
             {
                 var clientVersion = clientPlugin?.Version;
-                pluginDiffs.Add(new PluginDiff(clientVersion == lobbyPlugin.Version ? PluginDiffResult.Compatible : PluginDiffResult.Unknown, lobbyPlugin.GUID, clientVersion,
-                    lobbyPlugin.Version));
+                // Unknown mods with the same version are implicitly compatible, and will be added as compatible here
+                pluginDiffs.Add(new PluginDiff(
+                    clientVersion == lobbyPlugin.Version ? PluginDiffResult.Compatible : PluginDiffResult.Unknown,
+                    lobbyPlugin.GUID, clientVersion, lobbyPlugin.Version));
                 continue;
             }
 
@@ -92,8 +94,9 @@ internal static class LobbyHelper
             if (clientPlugin.CompatibilityLevel == null || clientPlugin.VersionStrictness == null)
             {
                 var lobbyVersion = lobbyPlugin?.Version;
-                pluginDiffs.Add(new PluginDiff(PluginDiffResult.Unknown, clientPlugin.GUID, clientPlugin.Version,
-                    lobbyVersion));
+                if (lobbyVersion != clientPlugin.Version)
+                    pluginDiffs.Add(new PluginDiff(PluginDiffResult.Unknown, clientPlugin.GUID, clientPlugin.Version,
+                        lobbyVersion));
                 continue;
             }
 

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -202,6 +202,18 @@ internal static class LobbyHelper
                 allLobbies.AddRange(incompatibleNormalLobbies);
             }
         }
+        else if (filteredLobbies == null && currentFilter is ModdedLobbyFilter.CompatibleFirst)
+        {
+            // Even if we can't find any filtered lobbies, try to sort any compatible lobbies we happen to find towards the front
+            var (compatibleNormalLobbies, otherNormalLobbies) =
+                SplitLobbiesByDiffResult(normalLobbies, LobbyDiffResult.Compatible);
+            var (presumedCompatibleNormalLobbies, incompatibleNormalLobbies) =
+                SplitLobbiesByDiffResult(normalLobbies, LobbyDiffResult.PresumedCompatible);
+
+            allLobbies.AddRange(compatibleNormalLobbies);
+            allLobbies.AddRange(presumedCompatibleNormalLobbies);
+            allLobbies.AddRange(incompatibleNormalLobbies);
+        }
         else if (filteredLobbies == null && currentFilter == ModdedLobbyFilter.CompatibleOnly)
         {
             // Handle the special case where we're sorting for compatible only and nothing comes up, so we need to force return nothing

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -50,7 +50,7 @@ internal static class LobbyHelper
             if (lobbyPlugin.CompatibilityLevel == null || lobbyPlugin.VersionStrictness == null)
             {
                 var clientVersion = clientPlugin?.Version;
-                pluginDiffs.Add(new PluginDiff(PluginDiffResult.Unknown, lobbyPlugin.GUID, clientVersion,
+                pluginDiffs.Add(new PluginDiff(clientVersion == lobbyPlugin.Version ? PluginDiffResult.Compatible : PluginDiffResult.Unknown, lobbyPlugin.GUID, clientVersion,
                     lobbyPlugin.Version));
                 continue;
             }

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -35,8 +35,11 @@ internal static class LobbyHelper
     internal static LobbyDiff GetLobbyDiff(Lobby lobby, string? lobbyPluginString)
     {
         if (LobbyDiffCache.TryGetValue(lobby.Id, out var cachedLobbyDiff))
+        {
+            LatestLobbyDiff = cachedLobbyDiff;
             return cachedLobbyDiff;
-        
+        }
+
         var lobbyPlugins = PluginHelper
             .ParseLobbyPluginsMetadata(lobbyPluginString ?? GetLobbyPlugins(lobby)).ToList();
         _clientPlugins ??= PluginHelper.GetAllPluginInfo().ToList();

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using HarmonyLib;
 using LobbyCompatibility.Enums;
 using LobbyCompatibility.Models;
@@ -13,6 +14,8 @@ namespace LobbyCompatibility.Features;
 /// </summary>
 internal static class LobbyHelper
 {
+    public static readonly Regex ModdedLobbyIdentifierRegex = new Regex(@"(\bmod(s|ded)?\b)", RegexOptions.IgnoreCase);
+
     public static Dictionary<string, string> LatestLobbyRequestStringFilters = new();
     public static LobbyDistanceFilter? LatestLobbyRequestDistanceFilter;
     private static List<PluginInfoRecord>? _clientPlugins;
@@ -286,5 +289,15 @@ internal static class LobbyHelper
             ModdedLobbyFilter.VanillaAndUnknownOnly => "No available vanilla or unknown\nservers to join.",
             _ => "No available servers to join."
         };
+    }
+
+    /// <summary>
+    ///     Returns true if a lobby name already contains a mod identifier, such as [MOD] or modded
+    /// </summary>
+    /// <param name="lobby"> The <see cref="Lobby" /> to check. </param>
+    /// <returns> True if the lobby name contains a mod idenitfier. </returns>
+    public static bool LobbyNameContainsModIdentifier(Lobby lobby)
+    {
+        return ModdedLobbyIdentifierRegex.IsMatch(lobby.GetData(LobbyMetadata.Name));
     }
 }

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -187,9 +187,19 @@ internal static class LobbyHelper
 
             if (currentFilter == ModdedLobbyFilter.CompatibleFirst)
             {
+                // Run a second pass to further seperate presumed compatible and non-compatible lobbies
+                var (presumedCompatibleFilteredLobbies, incompatibleFilteredLobbies) =
+                    SplitLobbiesByDiffResult(otherFilteredLobbies, LobbyDiffResult.PresumedCompatible);
+                var (presumedCompatibleNormalLobbies, incompatibleNormalLobbies) =
+                    SplitLobbiesByDiffResult(normalLobbies, LobbyDiffResult.PresumedCompatible);
+
+                // Add presumed compatible lobbies as a secondary, as they're very likely compatible (but not 100%)
+                allLobbies.AddRange(presumedCompatibleFilteredLobbies);
+                allLobbies.AddRange(presumedCompatibleNormalLobbies);
+
                 // Finally, add the non-compatible lobbies. We want to prioritize hashfilter non-compatible lobbies, as they're likely closer to compatibility.
-                allLobbies.AddRange(otherFilteredLobbies);
-                allLobbies.AddRange(otherNormalLobbies);
+                allLobbies.AddRange(incompatibleFilteredLobbies);
+                allLobbies.AddRange(incompatibleNormalLobbies);
             }
         }
         else if (filteredLobbies == null && currentFilter == ModdedLobbyFilter.CompatibleOnly)

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -204,9 +204,13 @@ internal static class PluginHelper
     /// <remarks> This means the client is allowed to have unknown or clientside mods. </remarks>
     internal static bool CanJoinVanillaLobbies()
     {
-        return GetAllPluginInfo().All(plugin =>
+        // Disabled until we have enough people using the mod to make this realistic to do
+        // If this was enabled immediately in first release, you would be unable to play with anyone who's missing LC, which will be nearly everyone
+        /* return GetAllPluginInfo().All(plugin =>
             plugin.CompatibilityLevel != CompatibilityLevel.Everyone &&
-            plugin.CompatibilityLevel != CompatibilityLevel.ClientOptional);
+            plugin.CompatibilityLevel != CompatibilityLevel.ClientOptional); */
+
+        return true;
     }
 
     /// <summary>

--- a/LobbyCompatibility/Features/UIHelper.cs
+++ b/LobbyCompatibility/Features/UIHelper.cs
@@ -194,7 +194,7 @@ internal static class UIHelper
             // Respawn mod diffs
             foreach (var mod in plugins)
             {
-                var pluginDiffSlot = pluginDiffSlotPool.Spawn(mod);
+                var pluginDiffSlot = pluginDiffSlotPool.Spawn(mod, lobbyDiff.LobbyCompatibilityPresent);
                 if (pluginDiffSlot == null)
                     continue;
 

--- a/LobbyCompatibility/Models/LobbyDiff.cs
+++ b/LobbyCompatibility/Models/LobbyDiff.cs
@@ -16,10 +16,19 @@ public record LobbyDiff(List<PluginDiff> PluginDiffs, bool LobbyCompatibilityPre
     /// <summary>
     ///     The text to display for this lobby in the UI.
     /// </summary>
+    /// <param name="shortened"> Shorten longer lobby type strings. </param>
     /// <returns> The text to display for this lobby in the UI. </returns>
-    public string GetDisplayText()
+    public string GetDisplayText(bool shortened = false)
     {
-        return $"Mod Status: {GetModdedLobbyType().ToString()}";
+        var lobbyType = GetModdedLobbyType();
+        string lobbyTypeString;
+
+        if (lobbyType == LobbyDiffResult.PresumedCompatible)
+            lobbyTypeString = shortened ? "Compatible?" : "Presumed Compatible";
+        else
+            lobbyTypeString = lobbyType.ToString();
+
+        return $"Mod Status: {lobbyTypeString}";
     }
 
     /// <summary>

--- a/LobbyCompatibility/Patches/MenuManagerPostfix.cs
+++ b/LobbyCompatibility/Patches/MenuManagerPostfix.cs
@@ -25,7 +25,8 @@ internal static class MenuManagerPostfix
 
         var listPanel = __instance.serverListUIContainer.transform.Find("ListPanel");
         var lobbyListScrollView = listPanel?.Find("Scroll View");
-        if (listPanel == null || lobbyListScrollView == null)
+        var privatePublicDescription = __instance.privatePublicDescription;
+        if (listPanel == null || lobbyListScrollView == null || privatePublicDescription == null)
             return;
 
         LobbyCompatibilityPlugin.Logger?.LogInfo("Initializing menu UI.");
@@ -43,11 +44,13 @@ internal static class MenuManagerPostfix
         var modListPanelNotification =
             Object.Instantiate(__instance.menuNotification, __instance.menuNotification.transform.parent);
 
+        // Get description text for bottom of modlist panel
+
         // Create actual panel handler (needs to be a seperate object because of the way notifications are structured)
         var modListPanelObject = new GameObject("ModListPanel Handler");
         modListPanelObject.transform.SetParent(__instance.menuNotification.transform.parent);
         var modListPanel = modListPanelObject.AddComponent<ModListPanel>();
-        modListPanel.SetupPanel(modListPanelNotification, lobbyListScrollView);
+        modListPanel.SetupPanel(modListPanelNotification, lobbyListScrollView, privatePublicDescription);
 
         // Make refresh button a more compact image so we have space for our custom dropdown
         var refreshButton = listPanel.Find("RefreshButton")?.GetComponent<Button>();

--- a/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
+++ b/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
@@ -44,7 +44,7 @@ internal static class SteamMatchmakingOnLobbyCreatedPostfix
         // Add a prefix to the lobby name to indicate that it's modded, if it doesn't already have some kind of modded mention
         if (pluginInfo.Any(plugin => plugin.CompatibilityLevel is CompatibilityLevel.ServerOnly
                 or CompatibilityLevel.Everyone or CompatibilityLevel.ClientOptional) &&
-            !lobby.GetData(LobbyMetadata.Name).ToLower().Contains("modded"))
+            !LobbyHelper.LobbyNameContainsModIdentifier(lobby))
             lobby.SetData(LobbyMetadata.Name, LobbyMetadata.ModdedLobbyPrefix + lobby.GetData(LobbyMetadata.Name));
 
         // Check if there are any required plugins in the lobby

--- a/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
+++ b/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
@@ -45,7 +45,7 @@ internal static class SteamMatchmakingOnLobbyCreatedPostfix
         if (pluginInfo.Any(plugin => plugin.CompatibilityLevel is CompatibilityLevel.ServerOnly
                 or CompatibilityLevel.Everyone or CompatibilityLevel.ClientOptional) &&
             !lobby.GetData(LobbyMetadata.Name).ToLower().Contains("modded"))
-            lobby.SetData(LobbyMetadata.Name, "modded // " + lobby.GetData(LobbyMetadata.Name));
+            lobby.SetData(LobbyMetadata.Name, LobbyMetadata.ModdedLobbyPrefix + lobby.GetData(LobbyMetadata.Name));
 
         // Check if there are any required plugins in the lobby
         if (pluginInfo.Any(plugin => plugin.CompatibilityLevel == CompatibilityLevel.Everyone))

--- a/LobbyCompatibility/Pooling/PluginDiffSlotPool.cs
+++ b/LobbyCompatibility/Pooling/PluginDiffSlotPool.cs
@@ -33,10 +33,11 @@ internal class PluginDiffSlotPool : MonoBehaviour
     ///     Spawns a <see cref="PluginDiffSlot"/> using the pool, and sets the text to match a <see cref="PluginDiff"/>.
     /// </summary>
     /// <param name="pluginDiff"> The <see cref="PluginDiff"/> to set the diff text to. </param>
-    public PluginDiffSlot? Spawn(PluginDiff pluginDiff)
+    /// <param name="lobbyCompatibilityPresent"> LobbyCompatibility is installed on the lobby. </param>
+    public PluginDiffSlot? Spawn(PluginDiff pluginDiff, bool lobbyCompatibilityPresent)
     {
         var pluginDiffSlot = SpawnInternal();
-        pluginDiffSlot?.SetPluginDiff(pluginDiff);
+        pluginDiffSlot?.SetPluginDiff(pluginDiff, lobbyCompatibilityPresent);
         return pluginDiffSlot;
     }
 


### PR DESCRIPTION
This PR:
- Fixes up any UI bugs arising from the new `PresumablyCompatible` enum
- Adds most of the minor features that need to be completed pre-demo
- Fixes minor UI inconsistency that demoers would notice
- Changes everything else that #32 needs to be fulfilled 

After this, the only thing that directly needs to be addressed before a demo is #12, which I already have a .txt file for.
I did not intend for this PR to have so many small things, please forgive me

### Changes
- Update hardcoded `LobbyCompatibility.Compatible` checks to support the new value `PresumablyCompatible` too
- Made null server version always display "?" in the modlist when Lobby type is `Unknown`, regardless of the plugin compatibility types
- Fix "CompatibleFirst" not putting compatible lobbies first if none were caught by the hashfilter (rarely there will be compatible lobbies not caught by the hashfilter, such as when the user has no `Everyone` mods)
- Change `PresumedCompatible` to display `Compatible(?)` and `Presumed Compatible` in the hover and full modlist panels respectively
- Rename `Unspecified` plugin compatibility header back to `Unknown`, if we want to change unknown to unspecified we should do it project-wide
- Made `Unknown` plugins with the same version on server/client implicitly compatible
- Made modlist scroll panel not shrink horizontally when it's too short for the scrollbar to appear
- Fix `Unknown` lobby type mod icons not showing as bright orange
- Fix `LatestLobbyDiff` not returning the correct value if it was cached
- Change `modded // ` lobby string prefix to `[MOD]`  (#34)
- Automatically removed `[MOD]` prefix from lobby names, while retaining the full 40 characters
- Temporarily remove vanilla lobby join disable to ease transition period
- Add conditional description text for when a lobby join fails

### Conditional description text examples
![image](https://github.com/MaxWasUnavailable/LobbyCompatibility/assets/34404266/6fd2e5a3-4d30-4575-99b4-ede41d9fe16d)
![image](https://github.com/MaxWasUnavailable/LobbyCompatibility/assets/34404266/559cc458-ab2f-445a-9f4b-ae9e95c67b5b)