### PR TITLE
Create a new Assembly Attribute for an easy Soft Dependency

### DIFF
--- a/LobbyCompatibility/Attributes/ICompatibilityAttribute.cs
+++ b/LobbyCompatibility/Attributes/ICompatibilityAttribute.cs
@@ -1,0 +1,26 @@
+using System;
+using LobbyCompatibility.Enums;
+
+namespace LobbyCompatibility.Attributes;
+
+/// <summary>
+///     The Compatibility Attribute interface.
+/// </summary>
+internal interface ICompatibilityAttribute
+{
+    /// <summary>
+    ///     Gets the compatibility level.
+    /// </summary>
+    /// <value>
+    ///     The compatibility level.
+    /// </value>
+    public CompatibilityLevel CompatibilityLevel { get; }
+
+    /// <summary>
+    ///     Gets the version strictness.
+    /// </summary>
+    /// <value>
+    ///     The version strictness.
+    /// </value>
+    public VersionStrictness VersionStrictness { get; }
+}

--- a/LobbyCompatibility/Attributes/LobbyCompatibilityAttribute.cs
+++ b/LobbyCompatibility/Attributes/LobbyCompatibilityAttribute.cs
@@ -8,14 +8,14 @@ namespace LobbyCompatibility.Attributes;
 /// </summary>
 /// <example>
 ///     <code>
-/// [LobbyCompatibilityAttribute(CompatibilityLevel.ServerOnly, VersionStrictness.Minor)]
+/// [LobbyCompatibility(CompatibilityLevel.ServerOnly, VersionStrictness.Minor)]
 /// class MyPlugin : BaseUnityPlugin
 /// {
 /// }
 ///     </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Class)]
-public sealed class LobbyCompatibilityAttribute : Attribute
+public sealed class LobbyCompatibilityAttribute : Attribute, ICompatibilityAttribute
 {
     /// <summary>
     ///     Initializes a new instance of the <see cref="LobbyCompatibilityAttribute" /> class.
@@ -28,19 +28,9 @@ public sealed class LobbyCompatibilityAttribute : Attribute
         VersionStrictness = versionStrictness;
     }
 
-    /// <summary>
-    ///     Gets the compatibility level.
-    /// </summary>
-    /// <value>
-    ///     The compatibility level.
-    /// </value>
+    /// <inheritdoc cref="ICompatibilityAttribute.CompatibilityLevel"/>
     public CompatibilityLevel CompatibilityLevel { get; }
-
-    /// <summary>
-    ///     Gets the version strictness.
-    /// </summary>
-    /// <value>
-    ///     The version strictness.
-    /// </value>
+    
+    /// <inheritdoc cref="ICompatibilityAttribute.VersionStrictness"/>
     public VersionStrictness VersionStrictness { get; }
 }

--- a/LobbyCompatibility/Attributes/SoftLobbyCompatibilityAttribute.cs
+++ b/LobbyCompatibility/Attributes/SoftLobbyCompatibilityAttribute.cs
@@ -1,0 +1,51 @@
+using System;
+using LobbyCompatibility.Enums;
+
+namespace LobbyCompatibility.Attributes;
+
+/// <summary>
+///     Specifies the compatibility of a plugin in a soft dependency manor.
+/// </summary>
+/// <example>
+///     <code>
+/// [assembly:SoftLobbyCompatibility(typeof(MyPlugin), CompatibilityLevel.ServerOnly, VersionStrictness.Minor)]
+/// 
+/// namespace ExampleMod;
+///
+/// public class MyPlugin : BaseUnityPlugin
+/// {
+/// }
+///     </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public sealed class SoftLobbyCompatibilityAttribute : Attribute, ICompatibilityAttribute
+{
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="SoftLobbyCompatibilityAttribute" /> class.
+    /// </summary>
+    /// <param name="plugin">The type of the plugin class.</param>
+    /// <param name="compatibilityLevel">The compatibility level.</param>
+    /// <param name="versionStrictness">The version strictness.</param>
+    public SoftLobbyCompatibilityAttribute(Type plugin,
+        CompatibilityLevel compatibilityLevel,
+        VersionStrictness versionStrictness)
+    {
+        Plugin = plugin;
+        CompatibilityLevel = compatibilityLevel;
+        VersionStrictness = versionStrictness;
+    }
+    
+    /// <summary>
+    ///     Gets the plugin type.
+    /// </summary>
+    /// <value>
+    ///     The plugin type.
+    /// </value>
+    public Type Plugin { get; }
+
+    /// <inheritdoc cref="ICompatibilityAttribute.CompatibilityLevel"/>
+    public CompatibilityLevel CompatibilityLevel { get; }
+    
+    /// <inheritdoc cref="ICompatibilityAttribute.VersionStrictness"/>
+    public VersionStrictness VersionStrictness { get; }
+}

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using BepInEx;
 using BepInEx.Bootstrap;
+using HarmonyLib;
 using LobbyCompatibility.Attributes;
 using LobbyCompatibility.Enums;
 using LobbyCompatibility.Models;
@@ -51,16 +52,20 @@ internal static class PluginHelper
     }
 
     /// <summary>
-    ///     Check if a plugin has the <see cref="LobbyCompatibilityAttribute" /> attribute.
+    ///     Check if a plugin has either the <see cref="LobbyCompatibilityAttribute" />
+    ///     or <see cref="SoftLobbyCompatibilityAttribute" /> attribute.
     /// </summary>
     /// <param name="plugin"> The plugin to check. </param>
     private static bool HasCompatibilityAttribute(BaseUnityPlugin plugin)
     {
-        return plugin.GetType().GetCustomAttributes(typeof(LobbyCompatibilityAttribute), false).Any();
+        return plugin.GetType().GetCustomAttributes(typeof(LobbyCompatibilityAttribute), false).Any()
+               || plugin.GetType().Assembly.GetCustomAttributes(typeof(SoftLobbyCompatibilityAttribute), false)
+                   .Any(attribute => ((SoftLobbyCompatibilityAttribute)attribute).Plugin == plugin.GetType());
     }
 
     /// <summary>
-    ///     Get all plugins that have the <see cref="LobbyCompatibilityAttribute" /> attribute.
+    ///     Get all plugins that have either the <see cref="LobbyCompatibilityAttribute" />
+    ///     or <see cref="SoftLobbyCompatibilityAttribute" /> attribute.
     /// </summary>
     private static IEnumerable<BepInEx.PluginInfo> GetCompatibilityPlugins()
     {
@@ -69,14 +74,16 @@ internal static class PluginHelper
     }
 
     /// <summary>
-    ///     Get the <see cref="LobbyCompatibilityAttribute" /> attribute of a plugin.
+    ///     Get the <see cref="ICompatibilityAttribute" /> attribute of a plugin.
     /// </summary>
     /// <param name="plugin"> The plugin to get the attribute from. </param>
-    /// <returns> The <see cref="LobbyCompatibilityAttribute" /> attribute of the plugin. </returns>
-    private static LobbyCompatibilityAttribute? GetCompatibilityAttribute(BaseUnityPlugin plugin)
+    /// <returns> The <see cref="ICompatibilityAttribute" /> attribute of the plugin. </returns>
+    private static ICompatibilityAttribute? GetCompatibilityAttribute(BaseUnityPlugin plugin)
     {
-        return (LobbyCompatibilityAttribute?)plugin.GetType()
-            .GetCustomAttributes(typeof(LobbyCompatibilityAttribute), false).FirstOrDefault();
+        return (plugin.GetType().GetCustomAttributes(typeof(LobbyCompatibilityAttribute), false).FirstOrDefault()
+                ?? plugin.GetType().Assembly.GetCustomAttributes(typeof(SoftLobbyCompatibilityAttribute), false)
+                    .FirstOrDefault(attribute => ((SoftLobbyCompatibilityAttribute)attribute).Plugin == plugin.GetType()))
+            as ICompatibilityAttribute;
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ class MyPlugin : BaseUnityPlugin
 }
 ```
 
+Another attribute available for soft dependencies is the `SoftLobbyCompatibility` attribute. To use this, you must provide the
+main plugin class type, the compatibility level, and the version strictness. This attribute ***must*** be located outside of the
+namespace definition in you classes. It only has to be used once, but can be used to register multiple mods if necessary.
+
+To use it, you can do it like so:
+
+```csharp
+[assembly: SoftLobbyCompatibility(typeof(ExampleMod.MyPlugin), CompatibilityLevel.Everyone, VersionStrictness.Minor)]
+
+namespace ExampleMod;
+
+[BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+[BepInDependency("BMX.LobbyCompatibility", DependencyFlags.SoftDependency)]
+class MyPlugin : BaseUnityPlugin
+{
+    // ...
+}
+```
+
 The enums used are as follows:
 
 ##### `CompatibilityLevel`
@@ -101,7 +120,7 @@ The enums used are as follows:
 
 #### Method
 
-Alternatively, as a way to support soft dependencies, you can use the `PluginHelper.RegisterPlugin` method with the
+Alternatively, as another way to support soft dependencies, you can use the `PluginHelper.RegisterPlugin` method with the
 following signature:
 
 ```csharp
@@ -111,7 +130,7 @@ public static void RegisterPlugin(string guid, Version version, CompatibilityLev
 > [!IMPORTANT]
 >
 > This method should be called in the `Awake` method of your plugin's main class, as we cache some data when fetching
-> the lobby list.
+> the lobby list or creating a new lobby.
 
 #### Retrieving & Using the LobbyDiff
 


### PR DESCRIPTION
Currently, for soft dependencies, you have to register your mod with the method provided, which modders would have to use a somewhat weird way to access that method only when this mod is loaded. Attributes are significantly easier and generally do not cause issues during runtime, however the current attribute causes issues due to how BepInEx attempts to load the "plugin" class - including the attribute - at runtime.

For this, a new attribute - currently called `SoftLobbyCompatibility` - is added in this PR. It is an assembly attribute that can be used to register a mod only when the Lobby Compatibility mod is loaded. The attribute is simple and clean.