### PR TITLE
Add Null Checks for Getting Loaded Plugins

### DIFF
--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -56,7 +56,8 @@ public static class PluginHelper
     /// <param name="plugin"> The plugin to check. </param>
     private static bool HasCompatibilityAttribute(BaseUnityPlugin plugin)
     {
-        return plugin.GetType().GetCustomAttributes(typeof(LobbyCompatibilityAttribute), false).Any();
+        return !ReferenceEquals(plugin, null) && 
+               plugin.GetType().GetCustomAttributes(typeof(LobbyCompatibilityAttribute), false).Any();
     }
 
     /// <summary>
@@ -90,7 +91,8 @@ public static class PluginHelper
 
         var compatibilityPlugins = GetCompatibilityPlugins().ToList();
         var nonCompatibilityPlugins = Chainloader.PluginInfos.Where(plugin =>
-            !HasCompatibilityAttribute(plugin.Value.Instance)).Select(plugin => plugin.Value).ToList();
+            !HasCompatibilityAttribute(plugin.Value.Instance) && !ReferenceEquals(plugin.Value.Instance, null))
+            .Select(plugin => plugin.Value).ToList();
         
         // We remove any plugins that have been registered manually to avoid duplicates
         compatibilityPlugins.RemoveAll(plugin =>

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -90,9 +90,9 @@ public static class PluginHelper
         var pluginInfos = new List<PluginInfoRecord>();
 
         var compatibilityPlugins = GetCompatibilityPlugins().ToList();
-        var nonCompatibilityPlugins = Chainloader.PluginInfos.Where(plugin =>
-            !ReferenceEquals(plugin.Value.Instance, null) && !HasCompatibilityAttribute(plugin.Value.Instance))
-            .Select(plugin => plugin.Value).ToList();
+        var nonCompatibilityPlugins = Chainloader.PluginInfos.Values.Where(plugin =>
+            !ReferenceEquals(plugin.Instance, null) && !HasCompatibilityAttribute(plugin.Instance))
+            .Select(plugin => plugin).ToList();
         
         // We remove any plugins that have been registered manually to avoid duplicates
         compatibilityPlugins.RemoveAll(plugin =>

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -91,7 +91,7 @@ public static class PluginHelper
 
         var compatibilityPlugins = GetCompatibilityPlugins().ToList();
         var nonCompatibilityPlugins = Chainloader.PluginInfos.Where(plugin =>
-            !HasCompatibilityAttribute(plugin.Value.Instance) && !ReferenceEquals(plugin.Value.Instance, null))
+            !ReferenceEquals(plugin.Value.Instance, null) && !HasCompatibilityAttribute(plugin.Value.Instance))
             .Select(plugin => plugin.Value).ToList();
         
         // We remove any plugins that have been registered manually to avoid duplicates


### PR DESCRIPTION
This adds a null check to prevent NREs that happen from unloaded plugins.

This should resolve #66.