### PR TITLE
Made the mod list UI not show if there is a custom disconnect reason

### DIFF
--- a/LobbyCompatibility/Patches/MenuManagerPostfix.cs
+++ b/LobbyCompatibility/Patches/MenuManagerPostfix.cs
@@ -16,8 +16,8 @@ namespace LobbyCompatibility.Patches;
 [HarmonyWrapSafe]
 internal static class MenuManagerPostfix
 {
-    [HarmonyPostfix]
-    private static void Postfix(MenuManager __instance)
+    [HarmonyPrefix]
+    private static void Prefix(MenuManager __instance)
     {
         // Don't run on startup screen
         if (__instance.isInitScene)
@@ -30,10 +30,7 @@ internal static class MenuManagerPostfix
             return;
 
         LobbyCompatibilityPlugin.Logger?.LogInfo("Initializing menu UI.");
-
-        // Set challenge moon leaderboard title text to not wrap halfway through
-        __instance.leaderboardHeaderText.rectTransform.offsetMax = new Vector2(2000, __instance.leaderboardHeaderText.rectTransform.offsetMax.y);
-
+        
         // Setup hover notification/tooltip UI
         var parent = __instance.menuNotification.transform.parent;
         
@@ -53,6 +50,21 @@ internal static class MenuManagerPostfix
         modListPanelObject.transform.SetParent(parent);
         var modListPanel = modListPanelObject.AddComponent<ModListPanel>();
         modListPanel.SetupPanel(modListPanelNotification, lobbyListScrollView, privatePublicDescription);
+    }
+    
+    [HarmonyPostfix]
+    private static void Postfix(MenuManager __instance)
+    {
+        // Don't run on startup screen
+        if (__instance.isInitScene)
+            return;
+
+        var listPanel = __instance.serverListUIContainer.transform.Find("ListPanel");
+        if (listPanel == null)
+            return;
+
+        // Set challenge moon leaderboard title text to not wrap halfway through
+        __instance.leaderboardHeaderText.rectTransform.offsetMax = new Vector2(2000, __instance.leaderboardHeaderText.rectTransform.offsetMax.y);
 
         // Make refresh button a more compact image so we have space for our custom dropdown
         var refreshButton = listPanel.Find("RefreshButton")?.GetComponent<Button>();

--- a/LobbyCompatibility/Patches/SetLoadingScreenPrefix.cs
+++ b/LobbyCompatibility/Patches/SetLoadingScreenPrefix.cs
@@ -23,6 +23,13 @@ internal static class SetLoadingScreenPrefix
 
         if (result != RoomEnter.Error)
             return true;
+
+        LobbyCompatibilityPlugin.Logger?.LogDebug("Error while joining! Logging Diff...");
+        LobbyCompatibilityPlugin.Logger?.LogDebug(
+            LobbyHelper.LatestLobbyDiff.PluginDiffs.Join(converter: diff => diff.GetDisplayText()));
+
+        if (!string.IsNullOrEmpty(GameNetworkManager.Instance.disconnectionReasonMessage))
+            return true;
         
         __instance.MenuAudio.volume = 0.5f;
         __instance.menuButtons.SetActive(true);
@@ -31,10 +38,6 @@ internal static class SetLoadingScreenPrefix
 
         if (ModListPanel.Instance != null)
             ModListPanel.Instance.DisplayNotification(LobbyHelper.LatestLobbyDiff, "Error while joining...");
-
-        LobbyCompatibilityPlugin.Logger?.LogDebug("Error while joining! Logging Diff...");
-        LobbyCompatibilityPlugin.Logger?.LogDebug(
-            LobbyHelper.LatestLobbyDiff.PluginDiffs.Join(converter: diff => diff.GetDisplayText()));
         
         return false;
     }


### PR DESCRIPTION
- Made the mod list UI not show if there is a custom disconnect reason
- Made the `MenuNotification` be cloned on the `Prefix` of `MenuManager.Start` instead of the `Postfix` (to fix it conflicting with LobbyImprovements)

Resolves https://github.com/MaxWasUnavailable/LobbyCompatibility/issues/74