### PR TITLE
LAN Fixes

### DIFF
--- a/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
+++ b/LobbyCompatibility/Behaviours/ModdedLobbySlot.cs
@@ -30,7 +30,8 @@ public class ModdedLobbySlot : MonoBehaviour
         _lobbySlot = lobbySlot;
 
         // Get the "diff" of the lobby
-        _lobbyDiff = LobbyHelper.GetLobbyDiff(_lobbySlot.thisLobby);
+        if (_lobbyDiff == null || !GameNetworkManager.Instance || !GameNetworkManager.Instance.disableSteam)
+            _lobbyDiff = LobbyHelper.GetLobbyDiff(_lobbySlot.thisLobby);
 
         // Find player count text (could be moved/removed in a future update, but unlikely)
         var playerCount = _lobbySlot.playerCount;

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -27,7 +28,7 @@ public static class LobbyHelper
     /// </summary>
     /// <param name="lobby"> The lobby to get the diff from. </param>
     /// <returns> The <see cref="LobbyDiff" /> from the <see cref="Lobby" />. </returns>
-    public static LobbyDiff GetLobbyDiff(Lobby lobby) => GetLobbyDiff(lobby, null);
+    public static LobbyDiff GetLobbyDiff(Lobby? lobby) => GetLobbyDiff(lobby, null);
 
     /// <summary>
     ///     Get a <see cref="LobbyDiff" /> from a <see cref="Lobby" /> or <see cref="IEnumerable{String}" />.
@@ -35,16 +36,16 @@ public static class LobbyHelper
     /// <param name="lobby"> The lobby to cache the diff to and/or get the diff from. </param>
     /// <param name="lobbyPluginString"> The json string to parse. </param>
     /// <returns> The <see cref="LobbyDiff" />. </returns>
-    internal static LobbyDiff GetLobbyDiff(Lobby lobby, string? lobbyPluginString)
+    internal static LobbyDiff GetLobbyDiff(Lobby? lobby, string? lobbyPluginString)
     {
-        if (LobbyDiffCache.TryGetValue(lobby.Id, out var cachedLobbyDiff))
+        if (lobby.HasValue && LobbyDiffCache.TryGetValue(lobby.Value.Id, out var cachedLobbyDiff))
         {
             LatestLobbyDiff = cachedLobbyDiff;
             return cachedLobbyDiff;
         }
 
         var lobbyPlugins = PluginHelper
-            .ParseLobbyPluginsMetadata(lobbyPluginString ?? GetLobbyPlugins(lobby)).ToList();
+            .ParseLobbyPluginsMetadata(lobbyPluginString ?? (lobby.HasValue ? GetLobbyPlugins(lobby.Value) : string.Empty)).ToList();
         _clientPlugins ??= PluginHelper.GetAllPluginInfo().ToList();
 
         var pluginDiffs = new List<PluginDiff>();
@@ -119,7 +120,8 @@ public static class LobbyHelper
         LatestLobbyDiff = new LobbyDiff(pluginDiffs, lobbyCompatibilityPresent);
 
         // Add to cache to avoid making multiple unnecessary GetData() calls
-        LobbyDiffCache.Add(lobby.Id, LatestLobbyDiff);
+        if (lobby.HasValue)
+            LobbyDiffCache.Add(lobby.Value.Id, LatestLobbyDiff);
 
         return LatestLobbyDiff;
     }

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -134,10 +134,13 @@ public static class LobbyHelper
     internal static string GetLobbyPlugins(Lobby lobby)
     {
         var lobbyPluginStrings = new List<string>();
-        var i = 0;
 
-        do lobbyPluginStrings.Insert(i, lobby.GetData($"{LobbyMetadata.Plugins}{i}"));
-        while (lobbyPluginStrings[i++].Contains("@"));
+        if (GameNetworkManager.Instance && !GameNetworkManager.Instance.disableSteam)
+        {
+            var i = 0;
+            do lobbyPluginStrings.Insert(i, lobby.GetData($"{LobbyMetadata.Plugins}{i}"));
+            while (lobbyPluginStrings[i++].Contains("@"));
+        }
 
         return lobbyPluginStrings
             .Join(delimiter: string.Empty)

--- a/LobbyCompatibility/Patches/MenuManagerPostfix.cs
+++ b/LobbyCompatibility/Patches/MenuManagerPostfix.cs
@@ -60,6 +60,7 @@ internal static class MenuManagerPostfix
             UIHelper.ReskinRefreshButton(refreshButton);
 
         // Add a custom "Mods" filtering type, and shift all other filtering UI elements to the left
-        UIHelper.AddCustomFilterToLobbyList(listPanel);
+        if (!GameNetworkManager.Instance || !GameNetworkManager.Instance.disableSteam)
+            UIHelper.AddCustomFilterToLobbyList(listPanel);
     }
 }

--- a/LobbyCompatibility/Patches/StartAClientPostfix.cs
+++ b/LobbyCompatibility/Patches/StartAClientPostfix.cs
@@ -1,0 +1,22 @@
+using HarmonyLib;
+using LobbyCompatibility.Features;
+
+namespace LobbyCompatibility.Patches;
+
+/// <summary>
+///     Patches <see cref="MenuManager.StartAClient" />.
+///     Checks if required plugins are present in the lobby metadata and are the same version as the client.
+/// </summary>
+/// <seealso cref="MenuManager.StartAClient" />
+[HarmonyPatch(typeof(MenuManager), nameof(MenuManager.StartAClient))]
+[HarmonyPriority(Priority.Last)]
+[HarmonyWrapSafe]
+internal static class StartAClientPostfix
+{
+    [HarmonyPrefix]
+    private static void Prefix()
+    {
+        // Create lobby diff so LatestLobbyDiff is set
+        LobbyHelper.GetLobbyDiff(null);
+    }
+}


### PR DESCRIPTION
- Fixed the client's mod list not showing on LAN
- Fixed exception when setting `ModdedLobbySlot._lobbyDiff` on LAN
- Removed lobby list filter dropdown on LAN (it doesn't do anything and there's not really any need for it)