### PR TITLE
Variable Compatibility Level

### DIFF
--- a/LobbyCompatibility/Enums/CompatibilityLevel.cs
+++ b/LobbyCompatibility/Enums/CompatibilityLevel.cs
@@ -29,5 +29,14 @@ public enum CompatibilityLevel
     ///     Generally used for mods that add extra (optional) functionality to the client if the server has it installed.
     ///     Mod must be loaded on server. Version checking depends on the VersionStrictness.
     /// </summary>
-    ClientOptional
+    ClientOptional,
+    
+    /// <summary>
+    ///     The compatibility level changes depending on the context of the lobby.
+    ///     Only very specific mods will ever use this, and it is highly discouraged to use this if you do not know what you are doing.
+    ///     If a value is not returned when the <see cref="LobbyCompatibility.Features.VariableCompatibilityCheckDelegate">check</see> is called, it will default to <see cref="CompatibilityLevel.ClientOnly"/>.
+    ///     Only usable for mods using the
+    ///     <see cref="LobbyCompatibility.Features.PluginHelper.RegisterPlugin(string, System.Version, CompatibilityLevel, VersionStrictness, LobbyCompatibility.Features.VariableCompatibilityCheckDelegate?)">RegisterPlugin</see> method.
+    /// </summary>
+    Variable,
 }

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -31,12 +31,20 @@ public static class LobbyHelper
     public static LobbyDiff GetLobbyDiff(Lobby? lobby) => GetLobbyDiff(lobby, null);
 
     /// <summary>
+    ///     Get a <see cref="LobbyDiff" /> from a <see cref="Lobby" />.
+    /// </summary>
+    /// <param name="lobby"> The lobby to get the diff from. </param>
+    /// <returns> The <see cref="LobbyDiff" /> from the <see cref="Lobby" />. </returns>
+    public static LobbyDiff GetLobbyDiff(IEnumerable<KeyValuePair<string, string>> lobbyData) => GetLobbyDiff(null, null, lobbyData);
+
+    /// <summary>
     ///     Get a <see cref="LobbyDiff" /> from a <see cref="Lobby" /> or <see cref="IEnumerable{String}" />.
     /// </summary>
     /// <param name="lobby"> The lobby to cache the diff to and/or get the diff from. </param>
     /// <param name="lobbyPluginString"> The json string to parse. </param>
+    /// <param name="lobbyData"> (Opt.) The lobby data. </param>
     /// <returns> The <see cref="LobbyDiff" />. </returns>
-    internal static LobbyDiff GetLobbyDiff(Lobby? lobby, string? lobbyPluginString)
+    internal static LobbyDiff GetLobbyDiff(Lobby? lobby, string? lobbyPluginString, IEnumerable<KeyValuePair<string, string>>? lobbyData = null)
     {
         if (lobby.HasValue && LobbyDiffCache.TryGetValue(lobby.Value.Id, out var cachedLobbyDiff))
         {
@@ -44,9 +52,11 @@ public static class LobbyHelper
             return cachedLobbyDiff;
         }
 
+        var lobbyDataList = lobbyData?.ToList();
+
         var lobbyPlugins = PluginHelper
-            .ParseLobbyPluginsMetadata(lobbyPluginString ?? (lobby.HasValue ? GetLobbyPlugins(lobby.Value) : string.Empty)).ToList();
-        _clientPlugins ??= PluginHelper.GetAllPluginInfo().ToList();
+            .ParseLobbyPluginsMetadata(lobbyPluginString ?? (lobby.HasValue ? GetLobbyPlugins(lobby.Value) : (GetLobbyPlugins(lobbyDataList ?? [])))).ToList();
+        _clientPlugins = PluginHelper.GetAllPluginInfo().CalculateCompatibilityLevel(lobby, lobbyDataList);
 
         var pluginDiffs = new List<PluginDiff>();
 
@@ -139,6 +149,27 @@ public static class LobbyHelper
         {
             var i = 0;
             do lobbyPluginStrings.Insert(i, lobby.GetData($"{LobbyMetadata.Plugins}{i}"));
+            while (lobbyPluginStrings[i++].Contains("@"));
+        }
+
+        return lobbyPluginStrings
+            .Join(delimiter: string.Empty)
+            .Replace("@", string.Empty);
+    }
+    
+    /// <summary>
+    ///     Get the plugins json from lobby data.
+    /// </summary>
+    /// <param name="lobbyData"> The lobby data that has the json string. </param>
+    /// <returns> A json <see cref="string" /> from the lobby data. </returns>
+    internal static string GetLobbyPlugins(List<KeyValuePair<string, string>> lobbyData)
+    {
+        var lobbyPluginStrings = new List<string>();
+
+        if (GameNetworkManager.Instance)
+        {
+            var i = 0;
+            do lobbyPluginStrings.Insert(i, lobbyData.FirstOrDefault(x => x.Key == $"{LobbyMetadata.Plugins}{i}").Value);
             while (lobbyPluginStrings[i++].Contains("@"));
         }
 

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -55,7 +55,7 @@ public static class LobbyHelper
         var lobbyDataList = lobbyData?.ToList();
 
         var lobbyPlugins = PluginHelper
-            .ParseLobbyPluginsMetadata(lobbyPluginString ?? (lobby.HasValue ? GetLobbyPlugins(lobby.Value) : (GetLobbyPlugins(lobbyDataList ?? [])))).ToList();
+            .ParseLobbyPluginsMetadata(lobbyPluginString ?? (lobby.HasValue ? GetLobbyPlugins(lobby.Value) : (lobbyDataList != null ? GetLobbyPlugins(lobbyDataList) : string.Empty))).ToList();
         _clientPlugins = PluginHelper.GetAllPluginInfo().CalculateCompatibilityLevel(lobby, lobbyDataList);
 
         var pluginDiffs = new List<PluginDiff>();

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -237,7 +237,7 @@ public static class PluginHelper
 
         PluginInfoRecord VariableCompat(PluginInfoRecord plugin)
         {
-            var compatibilityLevel = plugin.VariableCompatibilityCheck?.Invoke(lobbyData ?? (lobby?.Data ?? [])) ?? CompatibilityLevel.ClientOnly;
+            var compatibilityLevel = plugin.VariableCompatibilityCheck?.Invoke((lobby?.Data ?? lobbyData) ?? []) ?? CompatibilityLevel.ClientOnly;
             compatibilityLevel = compatibilityLevel is CompatibilityLevel.Variable ? CompatibilityLevel.ClientOnly : compatibilityLevel;
             
             LobbyCompatibilityPlugin.Logger?.LogDebug($"({plugin.GUID}) Variable Compatibility level: {compatibilityLevel}");

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -10,8 +10,11 @@ using LobbyCompatibility.Enums;
 using LobbyCompatibility.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Steamworks.Data;
 
 namespace LobbyCompatibility.Features;
+
+public delegate CompatibilityLevel VariableCompatibilityCheckDelegate(IEnumerable<KeyValuePair<string, string>> lobbyData);
 
 /// <summary>
 ///     Helper class for plugin related functions.
@@ -36,7 +39,7 @@ public static class PluginHelper
         get => _cachedChecksum ?? GetRequiredPluginsChecksum();
         set => _cachedChecksum = value;
     }
-    
+
     /// <summary>
     ///     Register a plugin's compatibility information manually.
     /// </summary>
@@ -44,9 +47,20 @@ public static class PluginHelper
     /// <param name="version"> The version of the plugin. </param>
     /// <param name="compatibilityLevel"> The compatibility level of the plugin. </param>
     /// <param name="versionStrictness"> The version strictness of the plugin. </param>
-    public static void RegisterPlugin(string guid, Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness)
+    public static void RegisterPlugin(string guid, Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness) =>
+        RegisterPlugin(guid, version, compatibilityLevel, versionStrictness, null);
+
+    /// <summary>
+    ///     Register a plugin's compatibility information manually.
+    /// </summary>
+    /// <param name="guid"> The GUID of the plugin. </param>
+    /// <param name="version"> The version of the plugin. </param>
+    /// <param name="compatibilityLevel"> The compatibility level of the plugin. </param>
+    /// <param name="versionStrictness"> The version strictness of the plugin. </param>
+    /// <param name="variableCompatibilityCheck"> (Opt.) The function to run when checking variable compatibility. In most cases, disregard. </param>
+    public static void RegisterPlugin(string guid, Version version, CompatibilityLevel compatibilityLevel, VersionStrictness versionStrictness, VariableCompatibilityCheckDelegate? variableCompatibilityCheck)
     {
-        RegisteredPluginInfoRecords.Add(new PluginInfoRecord(guid, version, compatibilityLevel, versionStrictness));
+        RegisteredPluginInfoRecords.Add(new PluginInfoRecord(guid, version, compatibilityLevel, versionStrictness, variableCompatibilityCheck));
         _cachedChecksum = null;
     }
 
@@ -118,9 +132,9 @@ public static class PluginHelper
     ///     Creates a list of json strings containing the metadata of all plugins, to add to the lobby.
     /// </summary>
     /// <returns> A list of json strings containing the metadata of all plugins. </returns>
-    internal static IEnumerable<string> GetLobbyPluginsMetadata()
+    internal static IEnumerable<string> GetLobbyPluginsMetadata(List<PluginInfoRecord>? plugins = null)
     {
-        var json = JsonConvert.SerializeObject(GetAllPluginInfo().ToList(), new VersionConverter());
+        var json = JsonConvert.SerializeObject(plugins ?? GetAllPluginInfo().ToList(), new VersionConverter());
 
         // The maximum string size for steam lobby metadata is 8192 (2^13).
         // We want one less than the maximum to allow space for a delimiter
@@ -207,6 +221,29 @@ public static class PluginHelper
                     return false;
 
         return true;
+    }
+
+    /// <summary>
+    ///     For Internal or Advanced Use Only.
+    ///     Checks for plugins with a CompatibilityLevel of Variable, then invokes the compatibility check to get the compatibility level of those plugins.
+    /// </summary>
+    /// <param name="pluginInfoRecords"> The plugin list. </param>
+    /// <param name="lobby"> (Opt.) The lobby. </param>
+    /// <param name="lobbyData"> (Opt.) The lobby data. </param>
+    /// <returns> A modified plugin list with correct compatibility levels. </returns>
+    public static List<PluginInfoRecord> CalculateCompatibilityLevel(this IEnumerable<PluginInfoRecord> pluginInfoRecords, Lobby? lobby = null, IEnumerable<KeyValuePair<string, string>>? lobbyData = null)
+    {
+        return pluginInfoRecords.Select(plugin => plugin.CompatibilityLevel is CompatibilityLevel.Variable ? VariableCompat(plugin) : plugin).ToList();
+
+        PluginInfoRecord VariableCompat(PluginInfoRecord plugin)
+        {
+            var compatibilityLevel = plugin.VariableCompatibilityCheck?.Invoke(lobbyData ?? (lobby?.Data ?? [])) ?? CompatibilityLevel.ClientOnly;
+            compatibilityLevel = compatibilityLevel is CompatibilityLevel.Variable ? CompatibilityLevel.ClientOnly : compatibilityLevel;
+            
+            LobbyCompatibilityPlugin.Logger?.LogDebug($"({plugin.GUID}) Variable Compatibility level: {compatibilityLevel}");
+
+            return plugin with { CompatibilityLevel = compatibilityLevel };
+        }
     }
 
     /// <summary>

--- a/LobbyCompatibility/Models/PluginInfoRecord.cs
+++ b/LobbyCompatibility/Models/PluginInfoRecord.cs
@@ -1,5 +1,6 @@
 using System;
 using LobbyCompatibility.Enums;
+using LobbyCompatibility.Features;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
@@ -14,6 +15,7 @@ namespace LobbyCompatibility.Models;
 /// <param name="Version"> The version of the plugin. </param>
 /// <param name="CompatibilityLevel"> The compatibility level of the plugin. </param>
 /// <param name="VersionStrictness"> The version strictness of the plugin. </param>
+/// <param name="VariableCompatibilityCheck"> A function called to decide the compatibility level, based off the lobby data. Must return a <see cref="LobbyCompatibility.Enums.CompatibilityLevel"/>. </param>
 [Serializable]
 public record PluginInfoRecord(
     [property:JsonProperty("i")]
@@ -27,5 +29,8 @@ public record PluginInfoRecord(
     CompatibilityLevel? CompatibilityLevel,
     
     [property:JsonProperty("s")]
-    VersionStrictness? VersionStrictness
+    VersionStrictness? VersionStrictness,
+    
+    [property:JsonIgnore]
+    VariableCompatibilityCheckDelegate? VariableCompatibilityCheck = null
 );

--- a/LobbyCompatibility/Patches/StartAClientPostfix.cs
+++ b/LobbyCompatibility/Patches/StartAClientPostfix.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using LobbyCompatibility.Features;
+using Steamworks.Data;
 
 namespace LobbyCompatibility.Patches;
 
@@ -17,6 +18,6 @@ internal static class StartAClientPostfix
     private static void Prefix()
     {
         // Create lobby diff so LatestLobbyDiff is set
-        LobbyHelper.GetLobbyDiff(null);
+        LobbyHelper.GetLobbyDiff((Lobby?)null);
     }
 }

--- a/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
+++ b/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
@@ -23,17 +23,17 @@ internal static class SteamMatchmakingOnLobbyCreatedPostfix
         // lobby has not yet been created or something went wrong
         if (result != Result.OK)
             return;
-
-        var pluginInfo = PluginHelper.GetAllPluginInfo().ToList();
+        
+        var pluginInfo = PluginHelper.GetAllPluginInfo().CalculateCompatibilityLevel(lobby);
 
         // Modded is flagged as true, since we're using mods
         lobby.SetData(LobbyMetadata.Modded, "true");
 
         // Add paginated plugin metadata to the lobby so clients can check if they have the required plugins
-        var plugins = PluginHelper.GetLobbyPluginsMetadata().ToArray();
+        var pluginsString = PluginHelper.GetLobbyPluginsMetadata(pluginInfo).ToArray();
         // Add each page - with a delimiter if there's another page
-        for (var i = 0; i < plugins.Length; i++)
-            lobby.SetData($"{LobbyMetadata.Plugins}{i}", $"{plugins[i]}{(i < plugins.Length - 1 ? "@" : string.Empty)}");
+        for (var i = 0; i < pluginsString.Length; i++)
+            lobby.SetData($"{LobbyMetadata.Plugins}{i}", $"{pluginsString[i]}{(i < pluginsString.Length - 1 ? "@" : string.Empty)}");
 
         // Set the joinable modded metadata to the same value as the original joinable metadata, in case it wasn't originally joinable
         lobby.SetData(LobbyMetadata.JoinableModded, lobby.GetData(LobbyMetadata.Joinable));


### PR DESCRIPTION
This PR adds a variable compatibility level for mods that change the compatibility based on the lobby data (e.g. More Company). 

The new compatibility level is `CompatibilityLevel.Variable`, and a (non-serialized) delegate was added to the PluginInfoRecord, which is called to determine the compatibility level, based on the lobby data. This occurs both during lobby creation, and lobby searching/joining.

Based on testing done by @1A3Dev, it looks like it works correctly.