### PR TITLE
Fixed LobbyMetadata Overflowing and Causing Errors

### DIFF
--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -64,13 +64,13 @@ public static class LobbyHelper
     public static LobbyDiff GetLobbyDiff(IEnumerable<KeyValuePair<string, string>> lobbyData) => GetLobbyDiff(null, null, lobbyData);
 
     /// <summary>
-    ///     Reduce the maximum string length for the plugins field in the lobby metadata.
+    ///     Reserve space in the lobby metadata.
     ///     Useful if you need larger space for lobby metadata for your mod.
     /// </summary>
-    /// <param name="length"> The max allowed length of LobbyCompatibility's plugin field on the lobby. Maxes out at <see cref="CurrentMaxPluginMetadataLength"/> (7800 on startup). </param>
-    public static void ReduceMaxLobbyMetadataStringLength(int length)
+    /// <param name="length"> The amount to metadata space in bytes space to reserve. The amound of bytes LobbyCompatibility will use is reduced by this amount. </param>
+    public static void ReserveLobbyMetadataSpace(int length)
     {
-        CurrentMaxPluginMetadataLength = length < CurrentMaxPluginMetadataLength ? length : CurrentMaxPluginMetadataLength;
+        CurrentMaxPluginMetadataLength -= length;
     }
 
     /// <summary>

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -230,7 +230,7 @@ public static class LobbyHelper
                 allowedPluginInfoRecords.RemoveAt(allowedPluginInfoRecords.Count - 1);
             } while (allowedPluginInfoRecords.Sum(record => record.JsonLength) + 1 + allowedPluginInfoRecords.Count > CurrentMaxPluginMetadataLength);
         
-            return JsonConvert.SerializeObject(plugins, new VersionConverter());
+            return JsonConvert.SerializeObject(allowedPluginInfoRecords, new VersionConverter());
         }
 
         do
@@ -240,7 +240,7 @@ public static class LobbyHelper
         
         allowedPluginInfoRecords.RemoveAt(allowedPluginInfoRecords.Count - 1);
         
-        return JsonConvert.SerializeObject(plugins, new VersionConverter());
+        return JsonConvert.SerializeObject(allowedPluginInfoRecords, new VersionConverter());
     }
 
     /// <summary>

--- a/LobbyCompatibility/Features/LobbyHelper.cs
+++ b/LobbyCompatibility/Features/LobbyHelper.cs
@@ -59,7 +59,7 @@ public static class LobbyHelper
     /// <summary>
     ///     Get a <see cref="LobbyDiff" /> from a <see cref="Lobby" />.
     /// </summary>
-    /// <param name="lobby"> The lobby to get the diff from. </param>
+    /// <param name="lobbyData"> The lobby to get the diff from. </param>
     /// <returns> The <see cref="LobbyDiff" /> from the <see cref="Lobby" />. </returns>
     public static LobbyDiff GetLobbyDiff(IEnumerable<KeyValuePair<string, string>> lobbyData) => GetLobbyDiff(null, null, lobbyData);
 
@@ -182,18 +182,12 @@ public static class LobbyHelper
     /// <returns> A json <see cref="string" /> from the <see cref="Lobby" />. </returns>
     internal static string GetLobbyPlugins(Lobby lobby)
     {
-        var lobbyPluginStrings = new List<string>();
-
         if (GameNetworkManager.Instance && !GameNetworkManager.Instance.disableSteam)
         {
-            var i = 0;
-            do lobbyPluginStrings.Insert(i, lobby.GetData($"{LobbyMetadata.Plugins}{i}"));
-            while (lobbyPluginStrings[i++].Contains("@"));
+            return lobby.GetData($"{LobbyMetadata.Plugins}0");
         }
 
-        return lobbyPluginStrings
-            .Join(delimiter: string.Empty)
-            .Replace("@", string.Empty);
+        return string.Empty;
     }
     
     /// <summary>

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -21,29 +21,6 @@ public delegate CompatibilityLevel VariableCompatibilityCheckDelegate(IEnumerabl
 /// </summary>
 public static class PluginHelper
 {
-    /// <summary>
-    ///     The absolute maximum string size for ALL steam lobby metadata is 8192 (2^13).
-    ///     We want to give a large enough margin for the checksum, vanilla game metadata, and any other modded metadata.
-    /// </summary>
-    private const int MaxPluginMetadataLength = 7800;
-
-    /// <summary>
-    ///     The average json string size of a plugin.
-    /// </summary>
-    /// <remarks> Calculated from `{"i":"BMX.LobbyCompatibility","v":"1.4.1","c":null,"s":null}` </remarks>
-    private const int AveragePluginJsonLength = 60;
-
-    /// <summary>
-    ///     The current maximum string size for the plugin field in lobby metadata.
-    /// </summary>
-    /// <remarks> WARNING: The absolute maximum string size for ALL steam lobby metadata is 8192 (2^13). </remarks>
-    public static int CurrentMaxPluginMetadataLength { get; private set; } = MaxPluginMetadataLength;
-
-    /// <summary>
-    ///     The maximum string size for ALL steam lobby metadata is 8192 (2^13).
-    ///     We want to give a large margin for the checksum, vanilla game metadata, and any other modded metadata.
-    /// </summary>
-    private static int AverageMaxLobbyMetadataModCount => CurrentMaxPluginMetadataLength / AveragePluginJsonLength;
     
     /// <summary>
     ///     PluginInfos registered through the register command, rather than found using the attribute.
@@ -86,16 +63,6 @@ public static class PluginHelper
     {
         RegisteredPluginInfoRecords.Add(new PluginInfoRecord(guid, version, compatibilityLevel, versionStrictness, variableCompatibilityCheck));
         _cachedChecksum = null;
-    }
-
-    /// <summary>
-    ///     Reduce the maximum string length for the plugins field in the lobby metadata.
-    ///     Useful if you need larger space for lobby metadata for your mod.
-    /// </summary>
-    /// <param name="length"> The max allowed length of LobbyCompatibility's plugin field on the lobby. Maxes out at <see cref="CurrentMaxPluginMetadataLength"/> (7800 on startup). </param>
-    public static void ReduceMaxLobbyMetadataStringLength(int length)
-    {
-        CurrentMaxPluginMetadataLength = length < CurrentMaxPluginMetadataLength ? length : CurrentMaxPluginMetadataLength;
     }
 
     /// <summary>
@@ -160,58 +127,6 @@ public static class PluginHelper
 
         // Finally, we concatenate the manually registered plugins and our discovered plugins
         return pluginInfos.Concat(RegisteredPluginInfoRecords);
-    }
-
-    /// <summary>
-    ///     Creates a json string containing the metadata of the maximum amount of plugins, sorted by highest compatibility requirement first.
-    /// </summary>
-    /// <returns> A json strings containing the maximum allowed mod count, as dictated by <see cref="CurrentMaxPluginMetadataLength"/>. </returns>
-    internal static string GetLobbyPluginsMetadata(List<PluginInfoRecord>? plugins = null)
-    {
-        plugins ??= GetAllPluginInfo().ToList();
-
-        plugins.Sort();
-
-        var allowedPluginInfoRecords = plugins.Take(AverageMaxLobbyMetadataModCount).ToList();
-
-        if (allowedPluginInfoRecords.Sum(record => record.JsonLength) + 1 + allowedPluginInfoRecords.Count > CurrentMaxPluginMetadataLength)
-        {
-            do
-            {
-                allowedPluginInfoRecords.RemoveAt(allowedPluginInfoRecords.Count - 1);
-            } while (allowedPluginInfoRecords.Sum(record => record.JsonLength) + 1 + allowedPluginInfoRecords.Count > CurrentMaxPluginMetadataLength);
-        
-            return JsonConvert.SerializeObject(plugins, new VersionConverter());
-        }
-
-        do
-        {
-            allowedPluginInfoRecords.Add(plugins[allowedPluginInfoRecords.Count]);
-        } while (allowedPluginInfoRecords.Sum(record => record.JsonLength) + 1 + allowedPluginInfoRecords.Count <= CurrentMaxPluginMetadataLength);
-        
-        allowedPluginInfoRecords.RemoveAt(allowedPluginInfoRecords.Count - 1);
-        
-        return JsonConvert.SerializeObject(plugins, new VersionConverter());
-    }
-
-    /// <summary>
-    ///     Parses a json string containing the metadata of all plugins.
-    /// </summary>
-    /// <param name="json"> The json string to parse. </param>
-    /// <returns> A list of plugins in the APIPluginInfo format. </returns>
-    internal static IEnumerable<PluginInfoRecord> ParseLobbyPluginsMetadata(string json)
-    {
-        try
-        {
-            return JsonConvert.DeserializeObject<List<PluginInfoRecord>>(json, new VersionConverter()) ??
-                   new List<PluginInfoRecord>();
-        }
-        catch (Exception e)
-        {
-            LobbyCompatibilityPlugin.Logger?.LogError("Failed to parse lobby plugins metadata.");
-            LobbyCompatibilityPlugin.Logger?.LogDebug(e);
-            throw;
-        }
     }
 
     /// <summary>

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -8,8 +8,6 @@ using BepInEx.Bootstrap;
 using LobbyCompatibility.Attributes;
 using LobbyCompatibility.Enums;
 using LobbyCompatibility.Models;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Steamworks.Data;
 
 namespace LobbyCompatibility.Features;

--- a/LobbyCompatibility/Features/PluginHelper.cs
+++ b/LobbyCompatibility/Features/PluginHelper.cs
@@ -22,6 +22,30 @@ public delegate CompatibilityLevel VariableCompatibilityCheckDelegate(IEnumerabl
 public static class PluginHelper
 {
     /// <summary>
+    ///     The absolute maximum string size for ALL steam lobby metadata is 8192 (2^13).
+    ///     We want to give a large enough margin for the checksum, vanilla game metadata, and any other modded metadata.
+    /// </summary>
+    private const int MaxPluginMetadataLength = 7800;
+
+    /// <summary>
+    ///     The average json string size of a plugin.
+    /// </summary>
+    /// <remarks> Calculated from `{"i":"BMX.LobbyCompatibility","v":"1.4.1","c":null,"s":null}` </remarks>
+    private const int AveragePluginJsonLength = 60;
+
+    /// <summary>
+    ///     The current maximum string size for the plugin field in lobby metadata.
+    /// </summary>
+    /// <remarks> WARNING: The absolute maximum string size for ALL steam lobby metadata is 8192 (2^13). </remarks>
+    public static int CurrentMaxPluginMetadataLength { get; private set; } = MaxPluginMetadataLength;
+
+    /// <summary>
+    ///     The maximum string size for ALL steam lobby metadata is 8192 (2^13).
+    ///     We want to give a large margin for the checksum, vanilla game metadata, and any other modded metadata.
+    /// </summary>
+    private static int AverageMaxLobbyMetadataModCount => CurrentMaxPluginMetadataLength / AveragePluginJsonLength;
+    
+    /// <summary>
     ///     PluginInfos registered through the register command, rather than found using the attribute.
     /// </summary>
     private static readonly List<PluginInfoRecord> RegisteredPluginInfoRecords = new();
@@ -62,6 +86,16 @@ public static class PluginHelper
     {
         RegisteredPluginInfoRecords.Add(new PluginInfoRecord(guid, version, compatibilityLevel, versionStrictness, variableCompatibilityCheck));
         _cachedChecksum = null;
+    }
+
+    /// <summary>
+    ///     Reduce the maximum string length for the plugins field in the lobby metadata.
+    ///     Useful if you need larger space for lobby metadata for your mod.
+    /// </summary>
+    /// <param name="length"> The max allowed length of LobbyCompatibility's plugin field on the lobby. Maxes out at <see cref="CurrentMaxPluginMetadataLength"/> (7800 on startup). </param>
+    public static void ReduceMaxLobbyMetadataStringLength(int length)
+    {
+        CurrentMaxPluginMetadataLength = length < CurrentMaxPluginMetadataLength ? length : CurrentMaxPluginMetadataLength;
     }
 
     /// <summary>
@@ -129,24 +163,35 @@ public static class PluginHelper
     }
 
     /// <summary>
-    ///     Creates a list of json strings containing the metadata of all plugins, to add to the lobby.
+    ///     Creates a json string containing the metadata of the maximum amount of plugins, sorted by highest compatibility requirement first.
     /// </summary>
-    /// <returns> A list of json strings containing the metadata of all plugins. </returns>
-    internal static IEnumerable<string> GetLobbyPluginsMetadata(List<PluginInfoRecord>? plugins = null)
+    /// <returns> A json strings containing the maximum allowed mod count, as dictated by <see cref="CurrentMaxPluginMetadataLength"/>. </returns>
+    internal static string GetLobbyPluginsMetadata(List<PluginInfoRecord>? plugins = null)
     {
-        var json = JsonConvert.SerializeObject(plugins ?? GetAllPluginInfo().ToList(), new VersionConverter());
+        plugins ??= GetAllPluginInfo().ToList();
 
-        // The maximum string size for steam lobby metadata is 8192 (2^13).
-        // We want one less than the maximum to allow space for a delimiter
-        var maxChunkLength = 8191;
-        
-        for (var i = 0; i < json.Length; i += maxChunkLength)
+        plugins.Sort();
+
+        var allowedPluginInfoRecords = plugins.Take(AverageMaxLobbyMetadataModCount).ToList();
+
+        if (allowedPluginInfoRecords.Sum(record => record.JsonLength) + 1 + allowedPluginInfoRecords.Count > CurrentMaxPluginMetadataLength)
         {
-            if (maxChunkLength + i > json.Length)
-                maxChunkLength = json.Length - i;
-
-            yield return json.Substring(i, maxChunkLength);
+            do
+            {
+                allowedPluginInfoRecords.RemoveAt(allowedPluginInfoRecords.Count - 1);
+            } while (allowedPluginInfoRecords.Sum(record => record.JsonLength) + 1 + allowedPluginInfoRecords.Count > CurrentMaxPluginMetadataLength);
+        
+            return JsonConvert.SerializeObject(plugins, new VersionConverter());
         }
+
+        do
+        {
+            allowedPluginInfoRecords.Add(plugins[allowedPluginInfoRecords.Count]);
+        } while (allowedPluginInfoRecords.Sum(record => record.JsonLength) + 1 + allowedPluginInfoRecords.Count <= CurrentMaxPluginMetadataLength);
+        
+        allowedPluginInfoRecords.RemoveAt(allowedPluginInfoRecords.Count - 1);
+        
+        return JsonConvert.SerializeObject(plugins, new VersionConverter());
     }
 
     /// <summary>

--- a/LobbyCompatibility/Models/PluginInfoRecord.cs
+++ b/LobbyCompatibility/Models/PluginInfoRecord.cs
@@ -35,11 +35,13 @@ public record PluginInfoRecord(
     VariableCompatibilityCheckDelegate? VariableCompatibilityCheck = null
 ) : IComparable<PluginInfoRecord>
 {
+    [JsonIgnore]
     private int? _jsonLength;
     
     /// <summary>
     ///     The calculated length of the json string.
     /// </summary>
+    [JsonIgnore]
     public int JsonLength => _jsonLength ??= 25 + GUID.Length + Version.ToString().Length + 
                                (CompatibilityLevel.HasValue ? 1 : 4) + (VersionStrictness.HasValue ? 1 : 4);
 

--- a/LobbyCompatibility/Models/PluginInfoRecord.cs
+++ b/LobbyCompatibility/Models/PluginInfoRecord.cs
@@ -33,7 +33,7 @@ public record PluginInfoRecord(
     
     [property:JsonIgnore]
     VariableCompatibilityCheckDelegate? VariableCompatibilityCheck = null
-)
+) : IComparable<PluginInfoRecord>
 {
     private int? _jsonLength;
     
@@ -47,18 +47,18 @@ public record PluginInfoRecord(
     {
         if (CompatibilityLevel != other.CompatibilityLevel)
         {
-            if (CompatibilityLevel is null) return -1;
-            if (other.CompatibilityLevel is null) return 1;
+            if (CompatibilityLevel is null) return 1;
+            if (other.CompatibilityLevel is null) return -1;
             
-            return (CompatibilityLevel ?? 0) - (other.CompatibilityLevel ?? 0);
+            return (other.CompatibilityLevel ?? 0) - (CompatibilityLevel ?? 0);
         }
         
         if (VersionStrictness != other.VersionStrictness)
         {
-            if (VersionStrictness is null) return -1;
-            if (other.VersionStrictness is null) return 1;
+            if (VersionStrictness is null) return 1;
+            if (other.VersionStrictness is null) return -1;
             
-            return (VersionStrictness ?? 0) - (other.VersionStrictness ?? 0);
+            return (other.VersionStrictness ?? 0) - (VersionStrictness ?? 0);
         }
 
         return string.Compare(GUID, other.GUID, StringComparison.Ordinal);

--- a/LobbyCompatibility/Models/PluginInfoRecord.cs
+++ b/LobbyCompatibility/Models/PluginInfoRecord.cs
@@ -33,4 +33,34 @@ public record PluginInfoRecord(
     
     [property:JsonIgnore]
     VariableCompatibilityCheckDelegate? VariableCompatibilityCheck = null
-);
+)
+{
+    private int? _jsonLength;
+    
+    /// <summary>
+    ///     The calculated length of the json string.
+    /// </summary>
+    public int JsonLength => _jsonLength ??= 25 + GUID.Length + Version.ToString().Length + 
+                               (CompatibilityLevel.HasValue ? 1 : 4) + (VersionStrictness.HasValue ? 1 : 4);
+
+    public int CompareTo(PluginInfoRecord other)
+    {
+        if (CompatibilityLevel != other.CompatibilityLevel)
+        {
+            if (CompatibilityLevel is null) return -1;
+            if (other.CompatibilityLevel is null) return 1;
+            
+            return (CompatibilityLevel ?? 0) - (other.CompatibilityLevel ?? 0);
+        }
+        
+        if (VersionStrictness != other.VersionStrictness)
+        {
+            if (VersionStrictness is null) return -1;
+            if (other.VersionStrictness is null) return 1;
+            
+            return (VersionStrictness ?? 0) - (other.VersionStrictness ?? 0);
+        }
+
+        return string.Compare(GUID, other.GUID, StringComparison.Ordinal);
+    }
+}

--- a/LobbyCompatibility/Patches/LobbyDataIsJoinablePostfix.cs
+++ b/LobbyCompatibility/Patches/LobbyDataIsJoinablePostfix.cs
@@ -47,7 +47,7 @@ internal static class LobbyDataIsJoinablePostfix
         }
 
         var matchesPluginRequirements =
-            PluginHelper.MatchesTargetRequirements(PluginHelper.ParseLobbyPluginsMetadata(lobbyPluginString));
+            PluginHelper.MatchesTargetRequirements(LobbyHelper.ParseLobbyPluginsMetadata(lobbyPluginString));
 
         if (!matchesPluginRequirements)
         {

--- a/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
+++ b/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
@@ -29,11 +29,10 @@ internal static class SteamMatchmakingOnLobbyCreatedPostfix
         // Modded is flagged as true, since we're using mods
         lobby.SetData(LobbyMetadata.Modded, "true");
 
-        // Add paginated plugin metadata to the lobby so clients can check if they have the required plugins
-        var pluginsString = PluginHelper.GetLobbyPluginsMetadata(pluginInfo).ToArray();
-        // Add each page - with a delimiter if there's another page
-        for (var i = 0; i < pluginsString.Length; i++)
-            lobby.SetData($"{LobbyMetadata.Plugins}{i}", $"{pluginsString[i]}{(i < pluginsString.Length - 1 ? "@" : string.Empty)}");
+        // Add plugin metadata to the lobby so clients can check if they have the required plugins
+        var pluginsString = PluginHelper.GetLobbyPluginsMetadata(pluginInfo);
+        
+        lobby.SetData($"{LobbyMetadata.Plugins}0", pluginsString);
 
         // Set the joinable modded metadata to the same value as the original joinable metadata, in case it wasn't originally joinable
         lobby.SetData(LobbyMetadata.JoinableModded, lobby.GetData(LobbyMetadata.Joinable));

--- a/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
+++ b/LobbyCompatibility/Patches/SteamMatchmakingOnLobbyCreatedPostfix.cs
@@ -30,7 +30,7 @@ internal static class SteamMatchmakingOnLobbyCreatedPostfix
         lobby.SetData(LobbyMetadata.Modded, "true");
 
         // Add plugin metadata to the lobby so clients can check if they have the required plugins
-        var pluginsString = PluginHelper.GetLobbyPluginsMetadata(pluginInfo);
+        var pluginsString = LobbyHelper.GetLobbyPluginsMetadata(pluginInfo);
         
         lobby.SetData($"{LobbyMetadata.Plugins}0", pluginsString);
 


### PR DESCRIPTION
Lobby Metadata has a maximum length of 8192 characters - for all metadata (not per entry). We were running into this limit when many mods were installed, so this should limit it to the maximum allowed.

I added sorting for it so that the stricter compatibility requirements are prioritized before other mods.

I also added a way for other mods to reduce the maximum allowed metadata length in case they need more metadata space than we allotted for.